### PR TITLE
Auto-detect GitHub username for zero-config first run

### DIFF
--- a/.claude/skills/config-format.md
+++ b/.claude/skills/config-format.md
@@ -31,3 +31,33 @@ When a skill needs a config value:
 2. Find the relevant section
 3. Extract the value after `**Key:**`
 4. If the value is a comment placeholder (`<!-- ... -->`), treat it as unconfigured and ask the user to set it up
+
+## GitHub Username Resolution
+
+When a skill needs the GitHub username, follow this fallback chain in order:
+
+### Step 1: Read config.md
+
+Read the GitHub → Username value from `config.md`. If it contains a real value (not a `<!-- ... -->` placeholder), use it. Done.
+
+### Step 2: Detect via `gh api user`
+
+Run `gh api user` and extract the `.login` field. This is the GitHub login, not the display name.
+
+If successful:
+- Use the detected username
+- Write it back to `config.md`, replacing the placeholder on the `- **Username:**` line in the GitHub section
+- Proceed with the skill
+
+If `gh` is not installed, not authenticated, or the call fails for any reason (network error, rate limit, etc.), silently fall through to Step 3. Do not show an error about `gh`.
+
+> **Note:** This is the one exception to the "always use the GitHub MCP plugin tools, not the `gh` CLI" rule. The `gh` CLI is used here only for username detection — never for PR queries or other GitHub API calls.
+
+### Step 3: Ask the user
+
+Prompt the user for their GitHub username. To help them, check `git config user.name` and include it as a hint — but since this returns a display name (e.g., "Brian Bell"), not a login (e.g., "brianbell"), never auto-accept it. The user must confirm or type their actual login.
+
+If the user provides a username:
+- Use it
+- Write it back to `config.md`, replacing the placeholder
+- Proceed with the skill

--- a/.claude/skills/my-prs/SKILL.md
+++ b/.claude/skills/my-prs/SKILL.md
@@ -11,8 +11,7 @@ Fetch and display your authored PRs with compact status. Parse review feedback i
 
 ### 1. Get GitHub Username
 
-Read `config.md` (per `config-format.md`) for the GitHub username.
-If unconfigured, ask the user.
+Resolve the GitHub username using the fallback chain defined in `config-format.md` (GitHub Username Resolution).
 
 ### 2. Fetch PRs
 

--- a/.claude/skills/review-prs/SKILL.md
+++ b/.claude/skills/review-prs/SKILL.md
@@ -11,8 +11,7 @@ Show PRs that need your review attention — requested reviews and mentions.
 
 ### 1. Get GitHub Username
 
-Read `config.md` (per `config-format.md`) for the GitHub username.
-If unconfigured, ask the user.
+Resolve the GitHub username using the fallback chain defined in `config-format.md` (GitHub Username Resolution).
 
 ### 2. Fetch PRs Awaiting Review
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ This repo is a personal command center for daily work. It combines an Obsidian k
 
 ## Key Files
 
-- `config.md` — GitHub username, Jira settings, preferences
+- `config.md` — GitHub username (auto-detected), Jira settings, preferences
 - `repos.md` — Registry of all git repositories with descriptions and tags
 - `ARCHITECTURE.md` — System architecture overview (maintained via `/architecture`)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A personal command center powered by [Claude Code](https://docs.anthropic.com/en
    cd ~/dev/new-primary-workflow
    ```
 
-2. **Fill in your config** — edit `config.md` with your GitHub username, Jira credentials, and preferences.
+2. **Fill in your config** — edit `config.md` with your Jira credentials and preferences. Your GitHub username is auto-detected from `gh` if authenticated; you can also set it manually in `config.md`.
 
 3. **Add your repositories** — edit `repos.md` with the repos you work on (name, URL, description, tags). Or run `/architecture` to do this interactively.
 

--- a/config.md
+++ b/config.md
@@ -1,7 +1,7 @@
 # Configuration
 
 ## GitHub
-- **Username:** <!-- your GitHub username -->
+- **Username:** <!-- auto-detected from gh cli, or set manually -->
 
 ## Jira
 - **Username:** <!-- your Jira username -->


### PR DESCRIPTION
## Summary

- Adds a three-step GitHub username resolution fallback chain to `config-format.md`: read from `config.md` → detect via `gh api user` → interactive prompt with `git config user.name` as a hint
- Updates `/my-prs` and `/review-prs` skills to reference the centralized fallback chain instead of duplicating resolution logic
- Updates `config.md` placeholder, `README.md`, and `CLAUDE.md` to reflect that GitHub username is now auto-detected

Closes #3

## Test plan

- [x] Run `/my-prs` with an unconfigured `config.md` and `gh` authenticated — username should be detected and written back
- [ ] Run `/my-prs` with an unconfigured `config.md` and `gh` not installed — should prompt interactively with `git config user.name` as hint
- [x] Run `/my-prs` with a configured `config.md` — should use the config value directly
- [ ] Verify `/review-prs` follows the same behavior
- [x] Verify Jira username config is unchanged