### PR TITLE
Rename project to Eddy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
-# Productivity Workflow Hub
+# Eddy
 
-This repo is a personal command center for daily work. It combines an Obsidian knowledge vault with workflow skills that should work with Claude Code or Codex to manage tasks, PRs, Jira tickets, and incoming information.
+*Your daily undercurrent of knowledge.*
+
+A second memory that combines an Obsidian knowledge vault with workflow skills for Claude Code or Codex to manage tasks, PRs, Jira tickets, and incoming information.
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# Productivity Workflow Hub
+# Eddy
 
-A personal command center powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Codex, and [Obsidian](https://obsidian.md). Manage tasks, PRs, Jira tickets, and incoming information from a single repo with 10 reusable workflow skills.
+*Your daily undercurrent of knowledge.*
+
+Manage tasks, PRs, Jira tickets, and incoming information from a single repo with reusable workflow skills.
+
+Powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex](https://chatgpt.com/codex) and [Obsidian](https://obsidian.md). 
 
 ## Prerequisites
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or Codex
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex](https://chatgpt.com/codex)
 - GitHub access through MCP/plugin integration if available, or the `gh` CLI as a fallback for PR workflows
 - [Obsidian](https://obsidian.md) (for browsing the knowledge graph)
 - [acli](https://bobswift.atlassian.net/wiki/spaces/ACLI/overview) (optional, for Jira integration)
@@ -45,7 +49,7 @@ A personal command center powered by [Claude Code](https://docs.anthropic.com/en
 | `/whats-next` | Prioritized list of what to work on next |
 | `/architecture` | Build/update the system architecture doc via interview |
 
-## Codex Skills
+## Codex Skills Installation
 
 Codex discovers installed skills from `~/.agents/skills`, not from this repo directly. The source of truth for these skills lives in `.claude/skills/`.
 


### PR DESCRIPTION
## Summary

- Rename from "Productivity Workflow Hub" to **Eddy** across README.md and CLAUDE.md
- Add tagline: *"Your daily undercurrent of knowledge."*
- Refine intro copy: replace "personal command center" with "a second memory"
- Add Codex link, clean up section headers, drop hardcoded skill count

## Context

An eddy is a place in a current where water curves back on itself, creating a pocket where things collect, recirculate, and surface. That's what this tool does — information flows past, the vault catches it, and patterns surface that you'd miss in the main current.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify CLAUDE.md is picked up correctly by Claude Code / Codex