### PR TITLE
Add Linear integration skill (/linear)

### DIFF
--- a/.claude/skills/config-format.md
+++ b/.claude/skills/config-format.md
@@ -28,6 +28,12 @@ Read `config.md` and extract values from the markdown list items. Each setting i
 
 These values are only needed if using the `/jira` skill. Other skills that surface ticket data (`/daily-plan`, `/whats-next`, `/recap`) read from cached vault notes in `notes/tickets/` and work fine without Jira configured.
 
+#### Linear
+- **Default Team** — Default Linear team for scoping queries and creating tickets (e.g., Backend)
+- **Backend** — Which integration to use: `linearis` (CLI, default) or `mcp` (Linear MCP server)
+
+These values are only needed if using the `/linear` skill.
+
 ## Usage in Skills
 
 When a skill needs a config value:

--- a/.claude/skills/daily-log-format.md
+++ b/.claude/skills/daily-log-format.md
@@ -52,6 +52,7 @@ Use these prefixes in brackets:
 | `my-prs` | /my-prs |
 | `review-prs` | /review-prs |
 | `jira` | /jira |
+| `linear` | /linear |
 | `daily-plan` | /daily-plan |
 | `recap` | /recap |
 | `architecture` | /architecture |

--- a/.claude/skills/eddy-setup/SKILL.md
+++ b/.claude/skills/eddy-setup/SKILL.md
@@ -5,7 +5,7 @@ description: Interactive onboarding wizard — configure vault, scan repos, and 
 
 # Eddy Setup Wizard
 
-Walk the user through onboarding: configure `config.md`, scan for repositories, and optionally set up Jira and work streams.
+Walk the user through onboarding: configure `config.md`, scan for repositories, and optionally set up Jira, Linear, and work streams.
 
 ## Process
 
@@ -70,7 +70,18 @@ Ask: "Do you use Jira for ticket tracking?"
 
 On re-run with existing Jira values, show each current value with the option to keep or change.
 
-### 6. Scan Dev Directory for Repositories
+### 6. Collect Linear Configuration (Optional)
+
+Ask: "Do you use Linear for ticket tracking?"
+
+- **If no** (or skip): Leave Linear values as placeholders (first run) or preserve existing values (re-run). Move on.
+- **If yes**: Collect two values:
+  - "What's your default Linear team? (e.g., Backend)"
+  - "Which backend do you want to use?" — offer `linearis` (CLI, default) or `mcp` (Linear MCP server). Briefly explain: linearis is a CLI tool (`npm install -g linearis`), MCP uses the official Linear MCP server.
+
+On re-run with existing Linear values, show each current value with the option to keep or change.
+
+### 7. Scan Dev Directory for Repositories
 
 List the immediate children of the dev directory that contain a `.git` directory:
 
@@ -101,7 +112,7 @@ Deselect any you don't want to register, or confirm to proceed.
 
 If no new repos are found, report that and move on.
 
-### 7. Offer Work Stream Creation (Optional)
+### 8. Offer Work Stream Creation (Optional)
 
 Briefly explain what work streams are:
 - "Work streams organize your tasks into coherent bodies of work — like an epic or initiative. Each gets its own todo list and can be linked to repos and Jira epics."
@@ -116,7 +127,7 @@ Then ask: "Would you like to create a work stream now? (You can always create th
 
 The wizard may offer to create multiple work streams by repeating the prompt.
 
-### 8. Show Summary and Confirm
+### 9. Show Summary and Confirm
 
 Display a complete summary of everything that will be written. Clearly distinguish between unchanged, updated, and new values:
 
@@ -128,6 +139,7 @@ Here's what I'll set up:
   Dev Directory:   ~/dev
   Default Branch:  main
   Jira:            skipped
+  Linear:          skipped
 
 📦 repos.md — 3 new repos
   + backflow — REST API service (go, backend)
@@ -151,6 +163,8 @@ On re-run, mark unchanged values:
   Jira Username:   brian.bell (new)
   Jira Project:    BACK (new)
   Jira Instance:   mycompany.atlassian.net (new)
+  Linear Team:     Backend (new)
+  Linear Backend:  linearis (new)
 ```
 
 **Wait for a single confirmation before writing any files.**
@@ -159,7 +173,7 @@ If nothing changed (re-run with all values current and no new repos), report:
 - "Everything is already up to date. No changes needed."
 Skip the write entirely.
 
-### 9. Write Files
+### 10. Write Files
 
 After the user confirms, write all files:
 
@@ -183,6 +197,10 @@ Write the full config file with the collected values:
 - **Username:** {jira_username or <!-- your Jira username -->}
 - **Default Project:** {jira_project or <!-- e.g., BACK -->}
 - **Instance:** {jira_instance or <!-- e.g., mycompany.atlassian.net -->}
+
+### Linear
+- **Default Team:** {linear_team or <!-- e.g., Backend -->}
+- **Backend:** {linear_backend or linearis} <!-- linearis | mcp -->
 ```
 
 #### repos.md
@@ -205,7 +223,7 @@ For each work stream the user chose to create:
 1. Create `notes/workstreams/{name}.md` from `notes/templates/workstream.md`, filling in the name and description. Leave repo and Jira epic fields as template placeholders.
 2. Create `notes/todos/{name}.md` from `notes/templates/todo.md`, filling in the work stream name.
 
-### 10. Update Daily Log
+### 11. Update Daily Log
 
 Open or create today's daily log at `notes/daily/YYYY-MM-DD.md`:
 - If it doesn't exist, create it from `notes/templates/daily.md`, filling in today's date.
@@ -220,8 +238,9 @@ Where `{details}` includes a brief summary of what was done, e.g.:
 - `, registered 3 repos`
 - `, created work stream [[error-handling-overhaul]]`
 - `, updated Jira config`
+- `, configured Linear (linearis backend)`
 
-### 11. Summarize
+### 12. Summarize
 
 Tell the user what was written and suggest next steps:
 - What files were created or updated

--- a/.claude/skills/jira/SKILL.md
+++ b/.claude/skills/jira/SKILL.md
@@ -155,6 +155,7 @@ project: <epic name>
 team: <project key>
 assignee: <assignee>
 priority: <priority>
+url: https://<instance>/browse/<KEY>
 date: <today>
 work_stream: <matched work stream or empty>
 ---
@@ -166,6 +167,7 @@ work_stream: <matched work stream or empty>
 - **Project:** [[<epic-name>]]
 - **Assignee:** <assignee>
 - **Priority:** <priority>
+- **URL:** https://<instance>/browse/<KEY>
 
 ## Comments
 <!-- Appended by comment mode -->

--- a/.claude/skills/linear/SKILL.md
+++ b/.claude/skills/linear/SKILL.md
@@ -56,7 +56,7 @@ If ambiguous, ask the user.
 3. Build query from user context
 4. Execute search (see Backend Commands)
    - **linearis:** Run `linearis issues list --query "<text>" --limit 25`. Parse the JSON response. If results need filtering by team/status/assignee, filter client-side since `--team`/`--status`/`--assignee` flags are not yet available (linearis-oss/linearis#124).
-   - **MCP:** Call `list_issues` with `query` param. If search fails (linear/linear#1028), fall back to `list_my_issues` and filter client-side.
+   - **MCP:** Call `list_issues` with `query` param. If search fails (linear/linear#1028), fall back to `list_my_issues` and filter client-side. **Note:** `list_my_issues` only returns the current user's issues. If using this fallback, tell the user: "Search fell back to your issues only — results may be incomplete. Use `linearis` backend for full team search."
 5. Display formatted results:
    ```
    ## Linear Tickets: <search context>
@@ -164,6 +164,7 @@ project: <Linear project name>
 team: <Linear team name>
 assignee: <assignee>
 priority: <priority name>
+url: <url from API/CLI response>
 date: <today>
 work_stream: <matched work stream or empty>
 ---
@@ -176,6 +177,7 @@ work_stream: <matched work stream or empty>
 - **Team:** <team>
 - **Assignee:** <assignee>
 - **Priority:** <priority name>
+- **URL:** <url>
 
 ## Comments
 <!-- Appended by comment mode -->
@@ -235,7 +237,7 @@ All linearis commands output JSON to stdout. Parse with standard JSON handling.
 **Important MCP notes:**
 - `save_issue` is a unified create/update tool — include the issue identifier to update, omit to create
 - Status field requires UUID, not name — always call `list_issue_statuses` first and resolve the name to UUID
-- `list_issues` `query` param has a known bug (linear/linear#1028) — if search fails, fall back to `list_my_issues` and filter client-side
+- `list_issues` `query` param has a known bug (linear/linear#1028) — if search fails, fall back to `list_my_issues` and filter client-side. Always inform the user when this fallback is used, since `list_my_issues` only returns the current user's issues
 
 ## Important Rules
 

--- a/.claude/skills/linear/SKILL.md
+++ b/.claude/skills/linear/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: linear
+description: Query, create, track, comment on, and update Linear tickets via linearis or MCP
+---
+
+# Linear
+
+Manage Linear tickets via linearis CLI or the official Linear MCP server. Find tickets, create new ones, check status, add comments, and update fields.
+
+## Process
+
+### 1. Check Prerequisites
+
+Read `config.md` (per `config-format.md`) for the **Backend** setting under `### Linear`.
+
+**If backend is `linearis` (default):**
+
+Run `which linearis` to verify linearis is installed. If not found, tell the user:
+> The `/linear` skill requires `linearis` CLI. This is an optional integration — Eddy works fine without it.
+>
+> To set it up: `npm install -g linearis`, then `linearis auth login`. See https://github.com/linearis-oss/linearis
+
+Then stop.
+
+**If backend is `mcp`:**
+
+The skill assumes the Linear MCP server is configured. If MCP tool calls fail with connection errors, surface:
+> Linear MCP server is not configured. Run `claude mcp add --transport http linear-server https://mcp.linear.app/mcp` and authenticate.
+
+### 2. Read Config
+
+Read `config.md` (per `config-format.md`) for:
+- **Default Team** — default Linear team for scoping queries
+- **Backend** — `linearis` (default) or `mcp`
+
+If Default Team is unconfigured and the mode needs it, ask the user.
+
+### 3. Determine Mode
+
+From the user's message, determine which mode to use:
+
+| Mode | Triggers |
+|------|----------|
+| **Find** | find, search, look for, what tickets, related to |
+| **Create** | create, new, make, write |
+| **Status** | status, what's happening, update on, how's, progress |
+| **Comment** | comment, reply, note on, add note |
+| **Update** | update, change, set, move, assign, close |
+
+If ambiguous, ask the user.
+
+### 4a. Find Mode
+
+1. Read `notes/workstreams/` for context — work stream descriptions, project names
+2. Check `notes/tickets/` for existing cached Linear tickets (files matching `linear-*.md`). To extract the Linear key from a vault filename, strip the `linear-` prefix (e.g., `linear-BACK-123.md` → `BACK-123`).
+3. Build query from user context
+4. Execute search (see Backend Commands)
+   - **linearis:** Run `linearis issues list --query "<text>" --limit 25`. Parse the JSON response. If results need filtering by team/status/assignee, filter client-side since `--team`/`--status`/`--assignee` flags are not yet available (linearis-oss/linearis#124).
+   - **MCP:** Call `list_issues` with `query` param. If search fails (linear/linear#1028), fall back to `list_my_issues` and filter client-side.
+5. Display formatted results:
+   ```
+   ## Linear Tickets: <search context>
+   
+   | Key | Title | Status | Priority | Assignee |
+   |-----|-------|--------|----------|----------|
+   | BACK-123 | Fix error types | In Progress | High | brian |
+   | BACK-124 | Add timeout handling | Todo | Medium | unassigned |
+   ```
+6. Cache referenced tickets as vault notes (see step 5 — Cache as Vault Notes)
+
+### 4b. Create Mode
+
+1. Read `notes/workstreams/` to infer team and project context
+2. Ask the user for details if not provided:
+   - Title
+   - Description
+   - Priority (default: Medium)
+3. Read default team from `config.md`, confirm or allow override
+4. Execute create (see Backend Commands)
+   - **linearis:** Run `linearis issues create "<title>" --team <team> --description "<desc>" --priority <n>` (add `--project "<project>"` and `--status "<status>"` if applicable). Priority uses Linear's numeric scale: 1=Urgent, 2=High, 3=Medium, 4=Low.
+   - **MCP:** Call `save_issue` with `title`, `team`, `description`, `priority`, `project`. Omit the issue identifier to create (not update). For status, call `list_issue_statuses` first to resolve the name to a UUID.
+5. Display the created ticket key
+6. Cache as vault note (see step 5 — Cache as Vault Notes)
+7. Offer to add to the relevant work stream's todo list
+8. Append `[linear]` entry to daily log
+
+### 4c. Status Mode
+
+1. Determine which tickets to check:
+   - From user's context, match to work streams and their associated projects
+   - Check existing cached notes in `notes/tickets/` where `system: linear`
+   - Build query for relevant tickets
+2. Execute search (see Backend Commands — same as Find)
+3. Display status summary:
+   ```
+   ## Linear Status: <context>
+   
+   | Key | Title | Status | Priority | Assignee |
+   |-----|-------|--------|----------|----------|
+   | BACK-123 | Fix error types | Done | High | brian |
+   | BACK-124 | Add timeout handling | In Progress | Medium | alice |
+   | BACK-125 | Update error docs | Todo | Low | unassigned |
+   
+   Progress: 1/3 done
+   ```
+4. Update cached vault notes with latest status
+
+### 4d. Comment Mode
+
+1. Parse the ticket key and comment text from the user's message
+2. If the ticket key is ambiguous, check `notes/tickets/` for recent Linear tickets and ask the user to confirm
+3. Show the user the comment text and ticket key, and ask them to confirm before posting
+4. Execute comment (see Backend Commands)
+   - **linearis:** Run `linearis comments create <KEY> --body "<text>"`
+   - **MCP:** Call `create_comment` with the issue identifier and comment body
+5. Update the cached vault note at `notes/tickets/linear-<KEY>.md`:
+   - If the vault note doesn't exist, create it using the unified schema (see step 5 — Cache as Vault Notes) first
+   - Append the comment to the **Comments** section:
+     ```
+     - **YYYY-MM-DD HH:MM** — <comment text>
+     ```
+6. Append to daily log:
+   ```
+   - **HH:MM** — [linear] Commented on [[linear-<KEY>]]: <short summary of comment>
+   ```
+
+### 4e. Update Mode
+
+1. Parse the ticket key, field to update, and new value from the user's message
+2. Supported fields (only these three):
+
+   **Status:**
+   - **linearis:** Run `linearis issues update <KEY> --status "<status>"`
+   - **MCP:** Call `list_issue_statuses` to resolve the status name to a UUID, then call `save_issue` with the issue identifier and the status UUID.
+
+   **Assignee:**
+   - **linearis:** Run `linearis issues update <KEY> --assignee "<name>"`
+   - **MCP:** Call `save_issue` with the issue identifier and assignee field.
+
+   **Priority:**
+   - **linearis:** Run `linearis issues update <KEY> --priority <n>` (1=Urgent, 2=High, 3=Medium, 4=Low)
+   - **MCP:** Call `save_issue` with the issue identifier and priority value.
+
+3. If the field to update is ambiguous, ask the user which field and new value
+4. Update the cached vault note at `notes/tickets/linear-<KEY>.md` to reflect the change:
+   - If the vault note doesn't exist, create it using the unified schema first
+   - Update the relevant frontmatter field and the Details section
+5. Append to daily log:
+   ```
+   - **HH:MM** — [linear] Updated [[linear-<KEY>]]: <field> → <new value>
+   ```
+
+### 5. Cache as Vault Notes
+
+For each ticket referenced, create or update `notes/tickets/linear-<KEY>.md` using the unified ticket schema (see `ticket-format.md`):
+
+```markdown
+---
+system: linear
+ticket_key: <KEY>
+title: "<title>"
+status: <status>
+project: <Linear project name>
+team: <Linear team name>
+assignee: <assignee>
+priority: <priority name>
+date: <today>
+work_stream: <matched work stream or empty>
+---
+
+# <KEY>: <title>
+
+## Details
+- **Status:** <status>
+- **Project:** [[<project>]]
+- **Team:** <team>
+- **Assignee:** <assignee>
+- **Priority:** <priority name>
+
+## Comments
+<!-- Appended by comment mode -->
+
+## Related
+<!-- Add wikilinks to work streams, PRs, notes -->
+```
+
+**Priority mapping:** Convert Linear's numeric values to human-readable names: 1=Urgent, 2=High, 3=Medium, 4=Low.
+
+**Work stream matching:** Compare ticket `project`, `title`, and `description` against work stream descriptions and repos. If a match is found, set `work_stream` in frontmatter and add a `[[Work Stream Name]]` wikilink in the Related section.
+
+### 6. Update Daily Log
+
+Append to `notes/daily/YYYY-MM-DD.md` (create from template if it doesn't exist):
+- Find: `- **HH:MM** — [linear] Searched Linear: <context> — found N tickets`
+- Create: `- **HH:MM** — [linear] Created ticket [[linear-<KEY>]]: <title>`
+- Status: `- **HH:MM** — [linear] Checked Linear status: <context> — N tickets, X done`
+- Comment: `- **HH:MM** — [linear] Commented on [[linear-<KEY>]]: <summary>`
+- Update: `- **HH:MM** — [linear] Updated [[linear-<KEY>]]: <field> → <new value>`
+
+## Backend Commands Reference
+
+### linearis CLI
+
+| Operation | Command |
+|-----------|---------|
+| Search | `linearis issues list --query "<text>" --limit 25` then filter JSON by team/status/assignee client-side |
+| Get issue | `linearis issues read <KEY>` |
+| Create | `linearis issues create "<title>" --team <team> --description "<desc>" --priority <n> [--project "<project>"] [--status "<status>"]` |
+| Comment | `linearis comments create <KEY> --body "<text>"` |
+| Update status | `linearis issues update <KEY> --status "<status>"` |
+| Update assignee | `linearis issues update <KEY> --assignee "<name>"` |
+| Update priority | `linearis issues update <KEY> --priority <n>` |
+| List teams | `linearis teams list` |
+| List projects | `linearis projects list` |
+
+Priority values: 1=Urgent, 2=High, 3=Medium, 4=Low.
+
+All linearis commands output JSON to stdout. Parse with standard JSON handling.
+
+**Known limitation:** `issues list` does not yet support `--team`/`--status`/`--assignee` filter flags (linearis-oss/linearis#124). Workaround: use `--query` for text search, then filter JSON results client-side.
+
+### Linear MCP
+
+| Operation | MCP Tool | Key Params |
+|-----------|----------|------------|
+| Search | `list_issues` | `query`, `label`, `limit` |
+| My issues | `list_my_issues` | — |
+| Get issue | `get_issue` | issue identifier, `includeRelations: true` |
+| Create | `save_issue` | `title`, `team`, `description`, `priority`, `project` |
+| Update | `save_issue` | issue identifier + fields to change |
+| Comment | `create_comment` | issue identifier, comment body |
+| List statuses | `list_issue_statuses` | — |
+| List labels | `list_issue_labels` | — |
+
+**Important MCP notes:**
+- `save_issue` is a unified create/update tool — include the issue identifier to update, omit to create
+- Status field requires UUID, not name — always call `list_issue_statuses` first and resolve the name to UUID
+- `list_issues` `query` param has a known bug (linear/linear#1028) — if search fails, fall back to `list_my_issues` and filter client-side
+
+## Important Rules
+
+- Always check for the configured backend's availability first
+- Cache tickets as vault notes for knowledge graph integration
+- Link vault notes to work streams via `[[wikilinks]]`
+- For create mode, always confirm the ticket details with the user before creating
+- For comment mode, always show the comment text and confirm before posting
+- Map Linear's numeric priority (1-4) to human-readable names in all vault output

--- a/.claude/skills/linear/SKILL.md
+++ b/.claude/skills/linear/SKILL.md
@@ -77,7 +77,7 @@ If ambiguous, ask the user.
    - Priority (default: Medium)
 3. Read default team from `config.md`, confirm or allow override
 4. Execute create (see Backend Commands)
-   - **linearis:** Run `linearis issues create "<title>" --team <team> --description "<desc>" --priority <n>` (add `--project "<project>"` and `--status "<status>"` if applicable). Priority uses Linear's numeric scale: 1=Urgent, 2=High, 3=Medium, 4=Low.
+   - **linearis:** Run `linearis issues create "<title>" --team <team> --description "<desc>" --priority <n>` (add `--project "<project>"` and `--status "<status>"` if applicable). Priority uses Linear's numeric scale: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low.
    - **MCP:** Call `save_issue` with `title`, `team`, `description`, `priority`, `project`. Omit the issue identifier to create (not update). For status, call `list_issue_statuses` first to resolve the name to a UUID.
 5. Display the created ticket key
 6. Cache as vault note (see step 5 — Cache as Vault Notes)
@@ -140,7 +140,7 @@ If ambiguous, ask the user.
    - **MCP:** Call `save_issue` with the issue identifier and assignee field.
 
    **Priority:**
-   - **linearis:** Run `linearis issues update <KEY> --priority <n>` (1=Urgent, 2=High, 3=Medium, 4=Low)
+   - **linearis:** Run `linearis issues update <KEY> --priority <n>` (0=None, 1=Urgent, 2=High, 3=Medium, 4=Low)
    - **MCP:** Call `save_issue` with the issue identifier and priority value.
 
 3. If the field to update is ambiguous, ask the user which field and new value
@@ -166,7 +166,7 @@ project: <Linear project name>
 team: <Linear team name>
 assignee: <assignee>
 priority: <priority name>
-url: <url from API/CLI response>
+url: <unavailable>
 date: <today>
 work_stream: <matched work stream or empty>
 ---
@@ -179,7 +179,7 @@ work_stream: <matched work stream or empty>
 - **Team:** <team>
 - **Assignee:** <assignee>
 - **Priority:** <priority name>
-- **URL:** <url>
+- **URL:** <unavailable>
 
 ## Comments
 <!-- Appended by comment mode -->
@@ -188,7 +188,9 @@ work_stream: <matched work stream or empty>
 <!-- Add wikilinks to work streams, PRs, notes -->
 ```
 
-**Priority mapping:** Convert Linear's numeric values to human-readable names: 1=Urgent, 2=High, 3=Medium, 4=Low.
+**Priority mapping:** Convert Linear's numeric values to human-readable names: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low. Tickets with no priority set return `0`.
+
+**URL field:** The `linearis` CLI does not expose issue URLs on `issues list`, `issues search`, or `issues read`. Always write the literal string `<unavailable>` for the `url` field in cached Linear ticket notes.
 
 **Work stream matching:** Compare ticket `project`, `title`, and `description` against work stream descriptions and repos. If a match is found, set `work_stream` in frontmatter and add a `[[Work Stream Name]]` wikilink in the Related section.
 
@@ -218,7 +220,7 @@ Append to `notes/daily/YYYY-MM-DD.md` (create from template if it doesn't exist)
 | List teams | `linearis teams list` |
 | List projects | `linearis projects list` |
 
-Priority values: 1=Urgent, 2=High, 3=Medium, 4=Low.
+Priority values: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low.
 
 All linearis commands output JSON to stdout. Parse with standard JSON handling.
 
@@ -249,4 +251,4 @@ All linearis commands output JSON to stdout. Parse with standard JSON handling.
 - Link vault notes to work streams via `[[wikilinks]]`
 - For create mode, always confirm the ticket details with the user before creating
 - For comment mode, always show the comment text and confirm before posting
-- Map Linear's numeric priority (1-4) to human-readable names in all vault output
+- Map Linear's numeric priority (0-4) to human-readable names in all vault output

--- a/.claude/skills/linear/SKILL.md
+++ b/.claude/skills/linear/SKILL.md
@@ -55,7 +55,7 @@ If ambiguous, ask the user.
 2. Check `notes/tickets/` for existing cached Linear tickets (files matching `linear-*.md`). To extract the Linear key from a vault filename, strip the `linear-` prefix (e.g., `linear-BACK-123.md` → `BACK-123`).
 3. Build query from user context
 4. Execute search (see Backend Commands)
-   - **linearis:** Run `linearis issues list --query "<text>" --limit 25`. Parse the JSON response. If results need filtering by team/status/assignee, filter client-side since `--team`/`--status`/`--assignee` flags are not yet available (linearis-oss/linearis#124).
+   - **linearis:** Run `linearis issues search "<text>" --limit 25`. Add `--team <team>`, `--status "<statuses>"`, `--assignee <user>`, or `--priority <n>` flags to filter server-side. Parse the JSON response.
    - **MCP:** Call `list_issues` with `query` param. If search fails (linear/linear#1028), fall back to `list_my_issues` and filter client-side. **Note:** `list_my_issues` only returns the current user's issues. If using this fallback, tell the user: "Search fell back to your issues only — results may be incomplete. Use `linearis` backend for full team search."
 5. Display formatted results:
    ```
@@ -90,7 +90,9 @@ If ambiguous, ask the user.
    - From user's context, match to work streams and their associated projects
    - Check existing cached notes in `notes/tickets/` where `system: linear`
    - Build query for relevant tickets
-2. Execute search (see Backend Commands — same as Find)
+2. Execute search (see Backend Commands)
+   - **linearis:** Use `linearis issues list --team <team> --status "<statuses>" --limit 25` to filter directly. Add `--assignee`, `--priority`, or `--project` flags as needed.
+   - **MCP:** Same as Find mode
 3. Display status summary:
    ```
    ## Linear Status: <context>
@@ -205,7 +207,8 @@ Append to `notes/daily/YYYY-MM-DD.md` (create from template if it doesn't exist)
 
 | Operation | Command |
 |-----------|---------|
-| Search | `linearis issues list --query "<text>" --limit 25` then filter JSON by team/status/assignee client-side |
+| Search | `linearis issues search "<text>" --limit 25 [--team <team>] [--status "<statuses>"] [--assignee <user>] [--priority <n>]` |
+| List (filtered) | `linearis issues list --team <team> [--status "<statuses>"] [--assignee <user>] [--priority <n>] --limit 25` |
 | Get issue | `linearis issues read <KEY>` |
 | Create | `linearis issues create "<title>" --team <team> --description "<desc>" --priority <n> [--project "<project>"] [--status "<status>"]` |
 | Comment | `linearis comments create <KEY> --body "<text>"` |
@@ -219,7 +222,7 @@ Priority values: 1=Urgent, 2=High, 3=Medium, 4=Low.
 
 All linearis commands output JSON to stdout. Parse with standard JSON handling.
 
-**Known limitation:** `issues list` does not yet support `--team`/`--status`/`--assignee` filter flags (linearis-oss/linearis#124). Workaround: use `--query` for text search, then filter JSON results client-side.
+**Filter flags:** `issues list` and `issues search` both support `--team`, `--status`, `--assignee`, `--creator`, `--project`, `--label`, `--priority`, `--cycle`, `--parent`, `--milestone`, `--estimate`, and date range flags (`--due-before`, `--due-after`, `--created-after`, `--created-before`, etc.). Use these for server-side filtering instead of filtering JSON client-side. Note: `--status` and `--cycle` require `--team`; `--milestone` requires `--project`.
 
 ### Linear MCP
 

--- a/.claude/skills/new-task/SKILL.md
+++ b/.claude/skills/new-task/SKILL.md
@@ -22,10 +22,10 @@ If the user's message contains what looks like a ticket number (e.g., "BACK-123"
 
 **If a cached ticket is found:** read its frontmatter and use the ticket's `title`, `project`, and `work_stream` to pre-populate the task context. The user can still override any pre-populated values.
 
-**If no cached ticket is found:** tell the user:
-> No cached ticket found for `<KEY>`. Run `/linear` or `/jira` to look it up first, then try again.
+**If no cached ticket is found:** warn the user and offer to continue:
+> No cached ticket found for `<KEY>`. You can run `/linear` or `/jira` to look it up and pre-populate context, or I can continue without it.
 
-Then stop.
+If the user chooses to continue, proceed to the Interview step with no pre-populated values. If the user wants to look it up first, stop and let them run the lookup skill.
 
 ### 3. Interview the User
 

--- a/.claude/skills/new-task/SKILL.md
+++ b/.claude/skills/new-task/SKILL.md
@@ -16,7 +16,18 @@ Read the following files to understand current state:
 - `repos.md` — available repositories
 - `ARCHITECTURE.md` — system context
 
-### 2. Interview the User
+### 2. Check for Ticket Reference
+
+If the user's message contains what looks like a ticket number (e.g., "BACK-123", "ENG-456"), check `notes/tickets/` for a cached note matching that key. Look for any file matching `*-<KEY>.md` (e.g., `linear-BACK-123.md`, `jira-BACK-123.md`).
+
+**If a cached ticket is found:** read its frontmatter and use the ticket's `title`, `project`, and `work_stream` to pre-populate the task context. The user can still override any pre-populated values.
+
+**If no cached ticket is found:** tell the user:
+> No cached ticket found for `<KEY>`. Run `/linear` or `/jira` to look it up first, then try again.
+
+Then stop.
+
+### 3. Interview the User
 
 If the user provided a task description in their message, use it. Otherwise, ask:
 - "What's the task?"
@@ -29,7 +40,7 @@ Then, present the active work streams and ask:
 
 Use structured questions where appropriate.
 
-### 3. Create/Update Files
+### 4. Create/Update Files
 
 Follow the conventions in `vault-conventions.md`, `workstream-format.md`, and `daily-log-format.md`.
 
@@ -51,7 +62,7 @@ Follow the conventions in `vault-conventions.md`, `workstream-format.md`, and `d
    - **HH:MM** — [new-task] Created task "Task Name" in [[Work Stream Name]]
    ```
 
-### 4. Summarize
+### 5. Summarize
 
 Tell the user what was created:
 - The todo entry and which work stream it's in

--- a/.claude/skills/ticket-format.md
+++ b/.claude/skills/ticket-format.md
@@ -22,9 +22,9 @@ work_stream: Eddy Development
 
 Required fields: `system`, `ticket_key`, `title`, `status`, `priority`, and `date`. All other fields are optional — include what's available from the tracker.
 
-**URL construction:** Each system has a predictable URL pattern:
-- Jira: `https://{instance}/browse/{KEY}` (instance from config.md)
-- Linear: use the `url` field returned by the API/CLI response
+**URL field:** Populate when the tracker exposes an addressable URL for the ticket:
+- Jira: construct as `https://{instance}/browse/{KEY}` (instance from config.md)
+- Linear: the `linearis` CLI does not expose issue URLs; use the literal value `<unavailable>`
 
 **Field mapping note:** `project` and `team` are system-agnostic names. In Jira, `project` maps to the epic name (or equivalent grouping) and `team` maps to the Jira project key (e.g., BACK). Other trackers should map their closest equivalents to these fields.
 
@@ -71,6 +71,7 @@ Linear uses a numeric priority scale. Map to human-readable names in vault notes
 
 | Linear Value | Vault Value |
 |-------------|-------------|
+| 0 | None |
 | 1 | Urgent |
 | 2 | High |
 | 3 | Medium |

--- a/.claude/skills/ticket-format.md
+++ b/.claude/skills/ticket-format.md
@@ -28,14 +28,16 @@ Required fields: `system`, `ticket_key`, `title`, `status`, `priority`, and `dat
 Files live in `notes/tickets/` and are named `{system}-{KEY}.md`:
 
 - Jira: `jira-BACK-1234.md`
+- Linear: `linear-BACK-123.md`
 
-The system prefix prevents collisions if additional trackers are added in the future.
+The system prefix prevents collisions when multiple trackers are in use.
 
 ## Wikilinks
 
 Link to tickets using the system-prefixed filename:
 
 - `[[jira-BACK-1234]]`
+- `[[linear-BACK-123]]`
 
 ## Ticket Note Template
 
@@ -56,6 +58,19 @@ Use `notes/templates/ticket.md` as the base. The body structure:
 ## Related
 <!-- Links to work streams, PRs, notes -->
 ```
+
+## Linear Field Mapping
+
+Linear uses a numeric priority scale. Map to human-readable names in vault notes:
+
+| Linear Value | Vault Value |
+|-------------|-------------|
+| 1 | Urgent |
+| 2 | High |
+| 3 | Medium |
+| 4 | Low |
+
+Linear `project` maps to the ticket `project` field. Linear `team` maps to the ticket `team` field.
 
 ## Linking Tickets to Work Streams
 
@@ -83,4 +98,13 @@ Jira uses the `[jira]` action type prefix:
 - **09:30** — [jira] Created ticket [[jira-BACK-1234]]: Fix auth timeout
 - **10:00** — [jira] Commented on [[jira-BACK-1234]]: investigating root cause
 - **10:15** — [jira] Updated [[jira-BACK-1234]]: status → In Progress
+```
+
+Linear uses the `[linear]` action type prefix:
+
+```markdown
+- **09:15** — [linear] Searched Linear: error handling — found 3 tickets
+- **09:30** — [linear] Created ticket [[linear-BACK-123]]: Fix auth timeout
+- **10:00** — [linear] Commented on [[linear-BACK-123]]: investigating root cause
+- **10:15** — [linear] Updated [[linear-BACK-123]]: status → In Progress
 ```

--- a/.claude/skills/ticket-format.md
+++ b/.claude/skills/ticket-format.md
@@ -14,12 +14,17 @@ project: Error Handling       # Jira epic or equivalent grouping
 team: BACK                    # Jira project key or equivalent
 assignee: brian-bell
 priority: High
+url: https://mycompany.atlassian.net/browse/BACK-1234
 date: 2026-04-08
 work_stream: Eddy Development
 ---
 ```
 
 Required fields: `system`, `ticket_key`, `title`, `status`, `priority`, and `date`. All other fields are optional — include what's available from the tracker.
+
+**URL construction:** Each system has a predictable URL pattern:
+- Jira: `https://{instance}/browse/{KEY}` (instance from config.md)
+- Linear: use the `url` field returned by the API/CLI response
 
 **Field mapping note:** `project` and `team` are system-agnostic names. In Jira, `project` maps to the epic name (or equivalent grouping) and `team` maps to the Jira project key (e.g., BACK). Other trackers should map their closest equivalents to these fields.
 
@@ -51,6 +56,7 @@ Use `notes/templates/ticket.md` as the base. The body structure:
 - **Project:** [[{project}]]
 - **Assignee:** {assignee}
 - **Priority:** {priority}
+- **URL:** {url}
 
 ## Comments
 <!-- Appended by comment mode -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ A second memory that combines an Obsidian knowledge vault with workflow skills f
 | `/my-prs` | Manage your authored PRs with review feedback todos |
 | `/review-prs` | List PRs awaiting your review action |
 | `/jira` | Query, create, track, comment on, and update Jira tickets via acli |
+| `/linear` | Query, create, track, comment on, and update Linear tickets via linearis or MCP |
 | `/daily-plan` | Create today's plan from calendar + priorities |
 | `/recap` | Daily or weekly summary of all activity |
 | `/whats-next` | Signal-based prioritized next actions |
@@ -36,7 +37,7 @@ The `notes/` directory is an Obsidian vault with these subdirectories:
 | `notes/daily/` | Daily logs (`YYYY-MM-DD.md`) — the spine of each day |
 | `notes/todos/` | Per-work-stream todo files with checkbox items |
 | `notes/prs/` | PR tracking notes with review feedback todos |
-| `notes/tickets/` | Cached ticket notes (Jira) |
+| `notes/tickets/` | Cached ticket notes (Jira, Linear) |
 | `notes/recaps/` | Daily and weekly recap summaries |
 | `notes/workstreams/` | Work stream definitions (explicit registry) |
 | `notes/squawk/` | Ingested items — Slack messages, emails, meeting notes |

--- a/config.md
+++ b/config.md
@@ -13,3 +13,7 @@
 - **Username:** <!-- your Jira username -->
 - **Default Project:** <!-- e.g., BACK -->
 - **Instance:** <!-- e.g., mycompany.atlassian.net -->
+
+### Linear
+- **Default Team:** <!-- e.g., Backend -->
+- **Backend:** linearis <!-- linearis | mcp -->

--- a/notes/templates/ticket.md
+++ b/notes/templates/ticket.md
@@ -7,6 +7,7 @@ project: {{project}}
 team: {{team}}
 assignee: {{assignee}}
 priority: {{priority}}
+url: {{url}}
 date: {{date}}
 work_stream: {{work_stream}}
 ---
@@ -18,6 +19,7 @@ work_stream: {{work_stream}}
 - **Project:** [[{{project}}]]
 - **Assignee:** {{assignee}}
 - **Priority:** {{priority}}
+- **URL:** {{url}}
 
 ## Comments
 <!-- Appended by comment mode -->


### PR DESCRIPTION
## Summary

Adds a `/linear` skill for managing Linear tickets with dual backend support (linearis CLI and Linear MCP server), plus convention updates to extend the unified ticket system to Linear.

## Changes

### New skill
- **`/linear`** with five modes: **find**, **create**, **status**, **comment**, **update**
- Dual backend: `linearis` CLI (default) or `mcp` (Linear MCP server), chosen via `config.md`
- Caches tickets as vault notes in `notes/tickets/linear-<KEY>.md` using the unified ticket schema
- Appends `[linear]` action entries to the daily log

### linearis backend
- Uses `linearis issues search <text>` for full-text search and `linearis issues list --team <team>` for filtered listing
- Supports server-side filter flags: `--team`, `--status`, `--assignee`, `--creator`, `--project`, `--label`, `--priority`, `--cycle`, `--parent`, `--milestone`, `--estimate`, and date ranges (reflects [linearis-oss/linearis#124](https://github.com/linearis-oss/linearis/pull/124))
- Priority mapping: `0=None, 1=Urgent, 2=High, 3=Medium, 4=Low`
- Documents that `linearis` does not expose issue URLs — cached notes use the literal `<unavailable>` for the `url` field

### MCP backend
- Uses `list_issues`, `save_issue`, `create_comment`, `list_issue_statuses` tools
- `save_issue` is unified create/update (include issue identifier to update, omit to create)
- Status field requires UUID resolution via `list_issue_statuses`
- Documents the `list_issues` fallback to `list_my_issues` on [linear/linear#1028](https://github.com/linear/linear/issues/1028) — warns the user since `list_my_issues` only returns the current user's issues

### Convention updates
- **`ticket-format.md`** — adds Linear file naming (`linear-<KEY>.md`), wikilinks, Linear field mapping (project/team), Linear priority table, and daily log examples. Adds `url` field with per-system guidance (Jira constructs from `{instance}/browse/{KEY}`, Linear uses `<unavailable>`).
- **`daily-log-format.md`** — adds `[linear]` action type prefix
- **`config-format.md`** — documents Linear config fields
- **`notes/templates/ticket.md`** — adds `url` field to frontmatter and Details body to match the unified schema

### Config
- **`config.md`** — adds `### Linear` section with `Default Team` and `Backend` fields
- **`/eddy-setup`** — adds step 6 to collect Linear configuration during onboarding

### Related skill updates
- **`/new-task`** — now checks `notes/tickets/` for a cached ticket matching any ticket reference in the user's message (e.g., `BACK-123`) to pre-populate title, project, and work stream. On cache miss, warns the user and offers to continue without pre-populated context (rather than stopping).

## Test plan

- [x] Verify `/linear` skill appears in Claude Code skill list
- [x] Run `/linear find <query>` with linearis backend — confirm `issues search` is used, results display, and ticket notes cached with `url: <unavailable>` and correct priority mapping
- [ ] Run `/linear find` with server-side filters (`--team`, `--status`, `--priority`) — confirm they're applied
- [ ] Run `/linear create` — confirm ticket creation, vault note caching, and daily log entry
- [ ] Run `/linear status` — confirm `issues list` with `--team` filter and status summary
- [ ] Run `/linear comment <KEY> <text>` — confirm comment posted and vault note updated
- [ ] Run `/linear update <KEY> status In Progress` — confirm update and vault note reflects change
- [ ] Switch config backend to `mcp` and verify MCP tool calls are used instead of linearis CLI
- [ ] Trigger the `list_issues` → `list_my_issues` fallback and verify the user is warned
- [ ] Run `/new-task BACK-123` with a cached ticket — confirm title/project/work_stream pre-populated
- [ ] Run `/new-task BACK-999` with no cached ticket — confirm warning + offer to continue

Closes #13