### PR TITLE
Document /linear skill in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,4 +57,5 @@ All skills MUST follow the conventions in `.claude/skills/vault-conventions.md` 
 See also:
 - `.claude/skills/daily-log-format.md` — Daily log conventions
 - `.claude/skills/workstream-format.md` — Work stream conventions
+- `.claude/skills/ticket-format.md` — Unified ticket schema (Jira, Linear)
 - `.claude/skills/config-format.md` — How to parse config.md

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Created 2 review feedback todos in notes/todos/
 | `/eddy-setup` | Interactive onboarding wizard for vault configuration |
 | `/architecture` | Build/update the system architecture doc via interview |
 | `/jira` | Find, create, or check status of Jira tickets ([setup required](#jira)) |
+| `/linear` | Find, create, or check status of Linear tickets ([setup required](#linear)) |
 
 ## Prerequisites
 
@@ -105,3 +106,14 @@ The `/jira` skill lets you find, create, and track Jira tickets from within Eddy
 To enable Jira integration:
 1. Install [acli](https://bobswift.atlassian.net/wiki/spaces/ACLI/overview) (Atlassian CLI) and configure authentication
 2. Fill in the Jira section under "Optional Integrations" in `config.md`
+
+### Linear
+
+The `/linear` skill lets you find, create, and track Linear tickets from within Eddy. Tickets are cached as vault notes under `notes/tickets/` so other skills (`/daily-plan`, `/whats-next`, `/recap`) can surface them alongside Jira.
+
+Choose one of two backends:
+
+- **linearis CLI** (default) — install with `npm install -g linearis`, then run `linearis auth login`. See [linearis-oss/linearis](https://github.com/linearis-oss/linearis).
+- **Linear MCP server** — run `claude mcp add --transport http linear-server https://mcp.linear.app/mcp` and authenticate.
+
+Then fill in the Linear section under "Optional Integrations" in `config.md` (Default Team and Backend).


### PR DESCRIPTION
## Summary

Fills two doc gaps left after #16 (the `/linear` skill) merged.

- **README.md** — adds `/linear` to the Skills table and a new `### Linear` section under Optional Integrations explaining the two backend choices (linearis CLI default, Linear MCP server opt-in) and how to configure them
- **CLAUDE.md** — adds `.claude/skills/ticket-format.md` to the convention docs "See also" list; it was introduced with the unified ticket system in #15 but the reference was never added

No source code or skill content changes — README/CLAUDE.md only.

## Test plan

- [ ] Render README.md on GitHub and confirm the Linear row and section render correctly
- [ ] Confirm the `[setup required](#linear)` anchor link jumps to the new section
- [ ] Confirm CLAUDE.md "See also" list now mentions ticket-format.md