### PR TITLE
Add ROADMAP.md and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,97 +23,52 @@ Powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Cod
 
 3. **Start using it** — try `/my-prs` to see your open PRs or `/daily-plan` to plan your day.
 
-## What You'll See
+### Start the Day
+- **`/daily-plan`** — Build today's plan from calendar + open todos + priorities
+- **`/whats-next`** — Prioritized next actions across all sources
 
-After `/eddy-setup`:
-```
-✓ Detected GitHub username: yourname
-✓ Found 12 repos in ~/dev
-✓ Config saved to config.md
-✓ Repos registered in repos.md
-```
+### Capture
+- **`/new-task`** — New task → categorize into work stream + todos
+- **`/ingest`** — Drop Slack/email/meeting notes into the vault
+- **`/idea`** — Quick idea capture with auto-metadata
 
-After `/my-prs`:
-```
-## Your Open PRs
+### Code & Ship
+- **`/start-coding`** — Clone repo into task folder with scaffolding
+- **`/commit`** / **`/ship`** — Commit / push + open PR
+- **`/rebase`** — Rebase on main, resolve conflicts
+- **`/my-prs`** — Your PRs: status, review feedback, conflicts
+- **`/review-prs`** — PRs awaiting your review
 
-| Repo | PR | Status | Reviews |
-|------|----|--------|---------|
-| api  | #42 Fix auth timeout | ✓ Approved | 2/2 |
-| web  | #108 Add dashboard | ● Changes requested | 1/2 |
+### Tickets
+- **`/jira`** — Query/create/update via acli
+- **`/linear`** — Query/create/update via linearis/MCP
 
-Created 2 review feedback todos in notes/todos/
-```
+### Reflect & Maintain
+- **`/recap`** — Daily or weekly summary
+- **`/architecture`** — Interview-driven ARCHITECTURE.md
+- **`/docs`** — Refresh CLAUDE.md + README.md
+- **`/eddy-setup`** — Onboarding / reconfigure vault
 
-## Skills
+### Vault Map (`notes/`)
+| Dir | What lives here |
+|---|---|
+| `daily/` | `YYYY-MM-DD.md` — spine of each day |
+| `todos/` | Per-work-stream checkbox files |
+| `prs/` | PR notes + review feedback todos |
+| `tickets/` | Cached Jira/Linear tickets |
+| `squawk/` | Ingested Slack/email/meeting notes |
+| `ideas/` | Passively tracked ideas |
+| `workstreams/` | Explicit work stream registry |
+| `recaps/` | Daily + weekly summaries |
+| `templates/` | Note templates |
 
-| Command | What it does |
-|---------|-------------|
-| `/daily-plan` | Plan your day from calendar + open work |
-| `/my-prs` | See your open PRs with status, review feedback as todos |
-| `/whats-next` | Prioritized list of what to work on next |
-| `/new-task` | Create a task, categorize it into a work stream, add todos |
-| `/start-coding` | Clone repos into a fresh task folder with full context |
-| `/ingest` | Paste Slack/email/etc. to capture, categorize, and extract action items |
-| `/idea` | Capture an idea for passive tracking with auto-inferred metadata |
-| `/review-prs` | See PRs waiting for your review |
-| `/recap` | Daily or weekly summary of what happened |
-| `/eddy-setup` | Interactive onboarding wizard for vault configuration |
-| `/architecture` | Build/update the system architecture doc via interview |
-| `/jira` | Find, create, or check status of Jira tickets ([setup required](#jira)) |
-| `/linear` | Find, create, or check status of Linear tickets ([setup required](#linear)) |
+### Rules of the Road
+- YAML frontmatter on every note
+- `[[wikilinks]]` between notes, `#tags` in body
+- Every skill appends to the daily log
+- Work streams are **never** auto-created — always confirm
 
-## Prerequisites
-
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex](https://chatgpt.com/codex)
-- GitHub access through MCP/plugin integration if available, or the `gh` CLI as a fallback for PR workflows
-- [Obsidian](https://obsidian.md) (for browsing the knowledge graph)
-
-## How It Works
-
-- **Obsidian vault** (`notes/`) stores everything as markdown with YAML frontmatter, `[[wikilinks]]`, and `#tags`
-- **Skills** are authored in `.claude/skills/`; for Codex, install them into `~/.agents/skills` with `./scripts/install-codex-skills.sh`
-- **Daily log** (`notes/daily/`) is the spine — every skill appends activity entries
-- **Work streams** (`notes/workstreams/`) organize tasks into coherent bodies of work
-- **Squawk** (`notes/squawk/`) captures ingested info from any source
-
-All vault data is plain markdown files in git — portable, searchable, and version-controlled.
-
-## Codex Skills Installation
-
-Codex discovers installed skills from `~/.agents/skills`, not from this repo directly. The source of truth for these skills lives in `.claude/skills/`.
-
-Install or refresh the Codex skill links with:
-
-```sh
-./scripts/install-codex-skills.sh
-```
-
-If you need to replace conflicting symlinks in `~/.agents/skills`, run:
-
-```sh
-./scripts/install-codex-skills.sh --force
-```
-
-Start a fresh Codex session after installing or updating these links.
-
-## Optional Integrations
-
-### Jira
-
-The `/jira` skill lets you find, create, and track Jira tickets from within Eddy. Other skills (`/daily-plan`, `/whats-next`, `/recap`) will include Jira data when available but work fine without it.
-
-To enable Jira integration:
-1. Install [acli](https://bobswift.atlassian.net/wiki/spaces/ACLI/overview) (Atlassian CLI) and configure authentication
-2. Fill in the Jira section under "Optional Integrations" in `config.md`
-
-### Linear
-
-The `/linear` skill lets you find, create, and track Linear tickets from within Eddy. Tickets are cached as vault notes under `notes/tickets/` so other skills (`/daily-plan`, `/whats-next`, `/recap`) can surface them alongside Jira.
-
-Choose one of two backends:
-
-- **linearis CLI** (default) — install with `npm install -g linearis`, then run `linearis auth login`. See [linearis-oss/linearis](https://github.com/linearis-oss/linearis).
-- **Linear MCP server** — run `claude mcp add --transport http linear-server https://mcp.linear.app/mcp` and authenticate.
-
-Then fill in the Linear section under "Optional Integrations" in `config.md` (Default Team and Backend).
+### Key Files
+- `config.md` — GitHub user, prefs, integrations
+- `repos.md` — Repo registry
+- `ARCHITECTURE.md` — System overview

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,93 @@
+# Eddy Roadmap
+
+Plan for aligning eddy with the daily operating guide — a workflow built around time-blocked days, a single curated running todo list, workstreams as doc-of-docs, and weekly Review → Reflect → Refine.
+
+## Principles we're aligning to
+
+- **Single running todo list**, curated daily, categorized by source (help-request, followup, meeting-action, self).
+- **Help the right people more** — team + key stakeholders' requests rank first.
+- **Workstreams are doc-of-docs**, not progress trackers.
+- **Time budget is reported, not enforced** — 5 named blocks (Admin / PR / Meetings / Hands On / Slack), weekly targets of 10h hands-on and 7.5h support.
+- **Friday Ritual** — Review → Reflect → Refine closes the week.
+- **P1 interrupts subtract in order** — Slack → Meetings → Hands On (last resort).
+
+## Out of scope (for now)
+
+- On-call mode.
+- Any hard enforcement of the time budget — reporting only.
+- WIP / multitasking signals (deferred to D3).
+
+## Phases
+
+Each phase lists t-shirt effort (S/M/L) and an ICE score (Impact × Confidence × Ease, each 1–10).
+
+### Phase A — Schema foundations
+
+| ID | Item | Effort | ICE |
+|---|---|---|---|
+| A1 | Collapse todos to a single running list | M | 360 |
+| A2 | Tighten workstream format to doc-of-docs | S | 360 |
+
+**A1 — Collapse todos to a single running list.**
+Move to `notes/todos/running.md` with per-item inline fields (workstream, source, added, stakeholder). Retire per-stream todo files; migrate existing items.
+Touches: `todo` template, `vault-conventions.md`, `workstream-format.md`, `/new-task`, `/daily-plan`, `/whats-next`, `/recap`.
+
+**A2 — Tighten workstream format to doc-of-docs.**
+Drop `## Tasks` from `workstream-format.md` and the workstream template. Rename to `## Links & Context` (notes, screenshots, decisions). Update `/new-task` to stop linking tasks into workstream files.
+
+### Phase B — Classification (enables "right people first")
+
+| ID | Item | Effort | ICE |
+|---|---|---|---|
+| B1 | Source-type axis on todos | M | 378 |
+| B2 | Key-stakeholders in `config.md` | S | 504 |
+
+**B1 — Source-type axis on todos.**
+Add `source: help-request | followup | meeting-action | self` per item, plus optional `from: @person`. Propagate through `/new-task`, `/ingest`, and the `/my-prs` review-feedback flow.
+
+**B2 — Key-stakeholders in `config.md`.**
+New `stakeholders:` list (team + key stakeholders). `/whats-next` and `/daily-plan` boost help-requests from this set to the top, reifying North Star #1.
+*Highest-leverage small change — do first.*
+
+### Phase C — Rituals (use the data)
+
+| ID | Item | Effort | ICE |
+|---|---|---|---|
+| C1 | Time-budget reporting | M | 240 |
+| C2 | Friday Ritual — extend `/recap weekly` | S | 392 |
+| C3 | `/replan` for P1 interrupts | M | 343 |
+
+**C1 — Time-budget reporting.**
+`/daily-plan`: classify each item into one of the 5 blocks and show estimated hours per block next to the guide's budget. `/recap daily`: tally completed hours by block. `/recap weekly`: roll up vs 10h hands-on / 7.5h support. Report-only.
+
+**C2 — Friday Ritual — extend `/recap weekly`.**
+Add Review → Reflect → Refine structure:
+- **Review** — hours vs target, shipped work, help given.
+- **Reflect** — prompts tied to the three north stars.
+- **Refine** — interactive prune of stale workstreams and running-list items.
+
+**C3 — `/replan` for P1 interrupts.**
+Takes a P1 description, re-draws today's plan subtracting in guide order (Slack → Meetings where possible → Hands On last), and logs the trade-off to the daily log.
+
+### Phase D — Nice-to-have
+
+| ID | Item | Effort | ICE |
+|---|---|---|---|
+| D1 | `/ingest` meeting mode | S | 294 |
+| D2 | Metrics cue in `/daily-plan` admin block | XS | 288 |
+| D3 | WIP-count warning in `/whats-next` | S | 210 |
+
+**D1 — `/ingest` meeting mode.** Read the last-ended calendar event, prompt for decisions + action items, route actions into the running list with `source: meeting-action`.
+
+**D2 — Metrics cue in `/daily-plan` admin block.** Surface dashboard links from a new `metrics_dashboards:` config field and ask "reviewed?". No tracking.
+
+**D3 — WIP-count warning in `/whats-next`.** Count simultaneous in-progress items; warn if >1, tied to North Star #2 ("stop doing multiple things at once").
+
+## Recommended build order
+
+B2 → A1 → A2 → B1 → C2 → C3 → C1 → D1 → D2 → D3.
+
+- **B2** is a one-line config change with the highest ICE — ship today.
+- **A1 / A2** unblock everything downstream; do them before behavior changes.
+- **B1** is the largest-impact behavior change; precede the rituals that use it.
+- **C2** comes before **C1** because it's self-contained and gives the Friday loop immediately; C1 adds hours data that C2 can fold in later.


### PR DESCRIPTION
## Summary
- Adds `ROADMAP.md` — a phased plan for aligning eddy's skills and vault schema with the daily operating guide. Phases are scored with ICE and sequenced by dependency:
  - **A** (schema): collapse todos to one running list; tighten workstream format to doc-of-docs
  - **B** (classification): source-type axis on todos; key-stakeholders in `config.md`
  - **C** (rituals): report-only time-budget, Friday Review→Reflect→Refine, `/replan` for P1 interrupts
  - **D** (nice-to-have): meeting-mode ingest, metrics cue, WIP warning
  - Out of scope for now: on-call mode, hard budget enforcement
- Refreshes `README.md` (prior local commit on main, included here so it ships in the same PR)

## Test plan
- [ ] Skim `ROADMAP.md` — phase order and out-of-scope items match intent
- [ ] Confirm `README.md` renders cleanly on GitHub