### PR TITLE
Add optional due date to todos; drive /daily-plan off of it

### DIFF
--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -29,7 +29,12 @@ Read across the vault to build a picture of what's pending:
 
 **Todos:**
 - Read `notes/todos/running.md` — collect unchecked (`- [ ]`) items.
-- For each item, parse the pipe-separated inline fields after the em-dash (`workstream`, `source`, `added`, `stakeholder`) per `vault-conventions.md`. Group / sort by `workstream` and use `source` and `stakeholder` to inform priority.
+- For each item, parse the pipe-separated inline fields after the em-dash (`workstream`, `source`, `added`, `due`, `stakeholder`) per `vault-conventions.md`.
+- Filter by `due` relative to today:
+  - **Include in today's plan:** items where `due` is today, items where `due` is before today (overdue), and items with no `due` field at all (undated items are always eligible).
+  - **Include in a "Coming up" section (not today's plan):** items where `due` is within the next 2 days (today+1 or today+2).
+  - **Exclude entirely:** items where `due` is more than 2 days out. These are effectively snoozed — surface them again when their window arrives.
+- Group / sort the eligible items by `workstream` and use `source` and `stakeholder` to inform priority. Flag overdue items prominently.
 
 **PR Actions:**
 - Read all files in `notes/prs/` — collect PRs with unchecked review feedback items
@@ -66,19 +71,23 @@ Calculate available focus time from the calendar. Then propose a prioritized pla
 ### Priorities
 1. **[PR] Address review feedback on backflow#142** (30 min)
    Why: Changes requested 2 days ago, blocking merge
-   
-2. **[Jira] BACK-1235 — Add timeout handling** (2 hours)
-   Why: In progress, assigned to you, blocks QA
-   
-3. **[Todo] Update error documentation** (1 hour)
-   Why: Part of Error Handling Overhaul, due this week
 
-4. **[Squawk] Respond to Alice's auth question** (15 min)
-   Why: Decision needed, ingested yesterday
+2. **[Todo] Ship retry policy doc** (1 hour) ⚠ OVERDUE
+   Why: Due 2026-04-14, still open — 2 days past
+
+3. **[Todo] Review Alice's auth RFC** (45 min) · due today
+   Why: Decision needed by EOD
+
+4. **[Todo] Update error documentation** (1 hour)
+   Why: No due date — steady progress on Error Handling Overhaul
 
 ### If Time Permits
 5. **[Todo] Explore WTUI color system** (1 hour)
-   Why: Design review tomorrow, helpful to have context
+   Why: Undated; design review prep
+
+### Coming Up (next 2 days)
+- **[Todo] Finalize Q2 roadmap** — due tomorrow (2026-04-17)
+- **[Todo] Prep for BACK-1240 review** — due 2026-04-18
 ```
 
 ### 5. Interview to Adjust
@@ -106,5 +115,9 @@ Print the final plan to the terminal.
 - Estimate time for each item based on complexity
 - Always explain WHY each item is prioritized (age, blocking, urgency, deadlines)
 - Include an "If Time Permits" section for lower-priority items
+- Include a **"Coming Up"** section listing items with `due` in the next 2 days (today+1, today+2) — these are not scheduled for today but the user should see them approaching. Omit the section if nothing qualifies.
+- Items with `due` more than 2 days out are excluded entirely — they're effectively snoozed until their window arrives. Users can adjust by editing the item's `due` field (see `vault-conventions.md` "Snoozing").
+- Undated items (no `due` field) are always eligible for today's plan; rank them by the usual signals.
+- Flag overdue items (`due` before today, still unchecked) prominently — e.g., ⚠ OVERDUE — and rank them at the top of Priorities.
 - Carry over unfinished items from yesterday's plan if applicable
 - Don't overwhelm — prioritize ruthlessly based on available focus time

--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -69,9 +69,10 @@ If the content contains action items, do **not** write them yet. First, propose 
 
 1. Extract each candidate action item from the content. For each one, draft a proposed line with inferred fields:
    ```
-   - [ ] <action description> [[YYYY-MM-DD-short-slug]] — workstream: <inferred> | source: help-request | added: YYYY-MM-DD | stakeholder: @<sender-if-known>
+   - [ ] <action description> [[YYYY-MM-DD-short-slug]] — workstream: <inferred> | source: help-request | added: YYYY-MM-DD | due: YYYY-MM-DD | stakeholder: @<sender-if-known>
    ```
    - `source` defaults to `help-request` for asks from other people, `followup` for things you owe back, `meeting-action` when the squawk is meeting-sourced, `self` when you're capturing your own thought. Omit if unclear.
+   - `due` is inferred only when the content states an explicit deadline ("by Friday", "end of week", an ISO date, a ticket with a due date). Resolve relative phrases against today. Leave out when no deadline is mentioned — undated items stay eligible every day.
    - `stakeholder` is the person being helped / the requester. Omit if unclear.
 2. Present the list to the user and ask them to:
    - confirm each item as-is,

--- a/.claude/skills/new-task/SKILL.md
+++ b/.claude/skills/new-task/SKILL.md
@@ -54,6 +54,7 @@ Follow the conventions in `vault-conventions.md`, `workstream-format.md`, and `d
    - [ ] Task description [[related-note]] — workstream: <work-stream-name> | added: YYYY-MM-DD
    ```
    - Always populate `workstream` and `added`.
+   - Add ` | due: YYYY-MM-DD` if the user stated a due date, mentioned "by <date>", referenced a deadline in the task description, or the task ties to a meeting / ticket with a known date. If unclear, ask: "Is there a due date? (blank to skip)". Leave `due` out when undated — undated items stay eligible for today's plan every day.
    - Add ` | stakeholder: @person` when the task description identifies a specific person being helped.
    - Omit `source` in Phase A — it is populated later (Phase B1).
    - Do not write into the work stream file's body.

--- a/.claude/skills/vault-conventions.md
+++ b/.claude/skills/vault-conventions.md
@@ -80,7 +80,7 @@ Every skill that creates or modifies vault data MUST append a summary entry to t
 All open todos live in one file, `notes/todos/running.md`. Each item is a Markdown checkbox line with pipe-separated inline fields after an em-dash:
 
 ```markdown
-- [ ] Task description [[optional-link]] — workstream: <name> | source: <type> | added: YYYY-MM-DD | stakeholder: @person
+- [ ] Task description [[optional-link]] — workstream: <name> | source: <type> | added: YYYY-MM-DD | due: YYYY-MM-DD | stakeholder: @person
 ```
 
 ### Item Fields
@@ -89,6 +89,7 @@ All open todos live in one file, `notes/todos/running.md`. Each item is a Markdo
 |-------|----------|-------------|
 | `workstream` | yes | Name of the related work stream (must match a file in `notes/workstreams/`) |
 | `added` | yes | ISO date (YYYY-MM-DD) when the item was added |
+| `due` | optional | ISO date (YYYY-MM-DD) by which the item should be done. If omitted, the item is always eligible for today's plan (no deadline). |
 | `source` | optional | Origin of the item: `help-request`, `followup`, `meeting-action`, `self`. Populated fully in Phase B1 — omit if unknown for now. |
 | `stakeholder` | optional | `@handle` of the person the item primarily serves (requester for help-requests, attendee for meeting actions, etc.) |
 | `completed` | on completion | ISO date when the checkbox is ticked. Append to the same trailing segment. |
@@ -99,6 +100,10 @@ All open todos live in one file, `notes/todos/running.md`. Each item is a Markdo
 - Keep the task description before the em-dash; fields come after.
 - Put `[[wikilinks]]` and `#tags` in the description portion, not the fields.
 - Skills that add items MUST populate `workstream` and `added` at minimum.
+
+### Snoozing
+
+To snooze an item, edit its `due` field to a later date. That's the whole mechanism — there is no separate snooze state. An item with `due: 2026-04-20` is simply not eligible for today's plan until that date arrives (see `/daily-plan` for the filtering rules). To defer indefinitely, remove the `due` field — but note that undated items are always eligible; if you want to hide something from the active plan, push the `due` date out instead.
 
 ## Work Stream Sovereignty
 

--- a/.claude/skills/whats-next/SKILL.md
+++ b/.claude/skills/whats-next/SKILL.md
@@ -15,7 +15,7 @@ Read across the entire vault:
 
 **Open Todos:**
 - Read `notes/todos/running.md` — collect all unchecked (`- [ ]`) items.
-- For each, parse the pipe-separated inline fields (`workstream`, `source`, `added`, `stakeholder`) per `vault-conventions.md`. Use `workstream` for grouping, `source` + `stakeholder` as ranking signals, and `added` for staleness.
+- For each, parse the pipe-separated inline fields (`workstream`, `source`, `added`, `due`, `stakeholder`) per `vault-conventions.md`. Use `workstream` for grouping, `source` + `stakeholder` as ranking signals, `added` for staleness, and `due` for urgency (overdue → highest boost; due today → high boost; due in 1–2 days → medium; undated → baseline; due further out → exclude from the main list since the user has explicitly snoozed them).
 
 **PR Actions:**
 - Read all files in `notes/prs/` — collect:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ The `notes/` directory is an Obsidian vault with these subdirectories:
 | Directory | Purpose |
 |-----------|---------|
 | `notes/daily/` | Daily logs (`YYYY-MM-DD.md`) — the spine of each day |
-| `notes/todos/` | Single running todo list at `running.md` with per-item inline fields (`workstream`, `source`, `added`, `stakeholder`) |
+| `notes/todos/` | Single running todo list at `running.md` with per-item inline fields (`workstream`, `source`, `added`, `due`, `stakeholder`) |
 | `notes/prs/` | PR tracking notes with review feedback todos |
 | `notes/tickets/` | Cached ticket notes (Jira, Linear) |
 | `notes/recaps/` | Daily and weekly recap summaries |

--- a/docs/migrations/running-todos.md
+++ b/docs/migrations/running-todos.md
@@ -7,6 +7,7 @@ If you started using Eddy before this change, your vault has per-work-stream tod
 - **Todos:** every per-stream file (`notes/todos/<stream>.md`) is replaced by one running list at `notes/todos/running.md`. Each item carries its workstream (and other context) inline.
 - **Work streams:** the `## Tasks` section is removed from the work stream template. `## Notes` stays. A new `## Links & Context` section is added for screenshots, decision docs, and external pointers.
 - **Skills:** `/start-coding` no longer creates todos or writes into the work stream body. `/ingest` now proposes todo items interactively instead of silently writing them.
+- **Due dates + snooze:** items now take an optional `due: YYYY-MM-DD` field. `/daily-plan` includes items due today, overdue items, and undated items; items due in the next 2 days appear in a "Coming Up" section; items due further out are hidden until their window arrives. Snooze by editing `due` to a later date — there is no separate snooze state. You do not need to backfill `due` during migration; leaving it off means the item stays eligible every day.
 
 See [ROADMAP.md](../../ROADMAP.md) for the rationale.
 

--- a/notes/templates/todo.md
+++ b/notes/templates/todo.md
@@ -9,7 +9,10 @@ One running list across all work streams. Each item is a checkbox line with
 pipe-separated inline fields after an em-dash.
 
 Format:
-  - [ ] <task description> [[optional-link]] — workstream: <name> | added: YYYY-MM-DD [ | source: <type>] [ | stakeholder: @person]
+  - [ ] <task description> [[optional-link]] — workstream: <name> | added: YYYY-MM-DD [ | due: YYYY-MM-DD] [ | source: <type>] [ | stakeholder: @person]
+
+Due date is optional. If omitted, the item is always eligible for today's plan.
+Snooze by editing `due` to a later date.
 
 On completion, append:  | completed: YYYY-MM-DD
 


### PR DESCRIPTION
Stacked on top of [#20](https://github.com/brian-bell/eddy/pull/20) (Phase A). Merge that one first.

## Summary

Adds an optional `due: YYYY-MM-DD` inline field to running-list items and teaches `/daily-plan` to filter by it. Snoozing is just editing the `due` field to a later date — no separate snooze state.

## Rules

**`/daily-plan`:**
- **Include in today's plan:** items with `due == today`, items with `due < today` (overdue, flagged prominently), and items with no `due` field (undated items are always eligible).
- **Coming Up section:** items with `due` in today+1 or today+2 — surfaced so they're visible approaching, but not scheduled for today.
- **Hidden:** items with `due > today+2` — effectively snoozed until their window arrives.

**`/whats-next`:** uses `due` as a ranking signal — overdue > due today > due in 1–2 days > undated (baseline) > further-out (hidden).

**Snooze:** edit the item's `due` field to push it out. Documented in [vault-conventions.md](../blob/claude/todo-due-dates/.claude/skills/vault-conventions.md#snoozing) and the migration guide.

## Item format

```
- [ ] Task description [[link]] — workstream: <name> | added: YYYY-MM-DD | due: YYYY-MM-DD | source: <type> | stakeholder: @person
```

`due` is optional. On completion, append `| completed: YYYY-MM-DD`.

## Files touched

- `.claude/skills/vault-conventions.md` — `due` field documented + "Snoozing" section.
- `.claude/skills/daily-plan/SKILL.md` — filter + "Coming Up" section + rules.
- `.claude/skills/whats-next/SKILL.md` — due as ranking signal.
- `.claude/skills/new-task/SKILL.md` — populate `due` when plausible; prompt if unclear.
- `.claude/skills/ingest/SKILL.md` — propose `due` when content states a deadline.
- `notes/templates/todo.md` — updated example.
- `docs/migrations/running-todos.md` — migration note: no backfill required.
- `CLAUDE.md` — directory description updated.

## Test plan

- [ ] `/new-task "ship retry policy by Friday"` — populates `due` with the correct ISO date (relative-phrase resolution).
- [ ] `/new-task` with no deadline cue leaves `due` off.
- [ ] `/ingest` of a message mentioning "by EOW" proposes a `due` date for the user to confirm.
- [ ] `/daily-plan` with items spanning all cases (overdue, today, tomorrow, day-after, far-future, undated) shows overdue + today + undated in Priorities, tomorrow + day-after in Coming Up, and omits far-future.
- [ ] Edit an item's `due` to 5 days out ("snooze"). Next `/daily-plan` excludes it. Edit it back to today → it reappears.
- [ ] `/whats-next` ranks an overdue item above a due-today item above an undated item with the same workstream.