### PR TITLE
Restore ## Tasks to workstreams; populated by /start-coding only

### DIFF
--- a/.claude/skills/start-coding/SKILL.md
+++ b/.claude/skills/start-coding/SKILL.md
@@ -83,7 +83,14 @@ If `AGENTS.md` already exists and is not a symlink to `CLAUDE.md`, ask the user 
 
 Follow `vault-conventions.md`, `workstream-format.md`, and `daily-log-format.md`.
 
-`/start-coding` does NOT write to `notes/todos/running.md` or to the work stream file body. It is a scaffolding skill — if the user needs a tracked todo for this task, they can add one with `/new-task`. Use `/start-coding` to match the task to a work stream (read-only), scaffold the task folder, and record the activity in the daily log.
+`/start-coding` does NOT write to `notes/todos/running.md`. If the user wants this task on the running todo list, they can add one with `/new-task`. It DOES append a line to the matched work stream's `## Tasks` section — that section is a historical log of coding tasks started against the stream, and `/start-coding` is the only skill that writes to it.
+
+#### Append to the work stream `## Tasks` section:
+Find the matched work stream file at `notes/workstreams/<stream>.md` and append a bullet to its `## Tasks` section (create the section just above `## Notes` if it is missing — templates written before this change may lack it):
+```
+- <task-name>: <brief description> — started YYYY-MM-DD
+```
+Do not touch any other section of the work stream file.
 
 #### Update daily log:
 Append to `notes/daily/YYYY-MM-DD.md`:
@@ -96,8 +103,9 @@ Append to `notes/daily/YYYY-MM-DD.md`:
 Tell the user:
 - Task folder location and what was cloned
 - The `CLAUDE.md` created with context and the `AGENTS.md` symlink pointing to it
+- The work stream `## Tasks` bullet appended (quote the line added)
 - The daily log entry
-- A nudge: "If you want this tracked on the running todo list, run `/new-task`."
+- A nudge: "If you want this tracked on the running todo list too, run `/new-task`."
 - How to start working: `cd <task-folder>` and launch Claude Code or Codex
 
 ## Important Rules

--- a/.claude/skills/start-coding/SKILL.md
+++ b/.claude/skills/start-coding/SKILL.md
@@ -86,11 +86,11 @@ Follow `vault-conventions.md`, `workstream-format.md`, and `daily-log-format.md`
 `/start-coding` does NOT write to `notes/todos/running.md`. If the user wants this task on the running todo list, they can add one with `/new-task`. It DOES append a line to the matched work stream's `## Tasks` section — that section is a historical log of coding tasks started against the stream, and `/start-coding` is the only skill that writes to it.
 
 #### Append to the work stream `## Tasks` section:
-Find the matched work stream file at `notes/workstreams/<stream>.md` and append a bullet to its `## Tasks` section (create the section just above `## Notes` if it is missing — templates written before this change may lack it):
+Find the matched work stream file at `notes/workstreams/<stream>.md` and append a bullet in the open form from `notes/templates/task.md`:
 ```
-- <task-name>: <brief description> — started YYYY-MM-DD
+- <task-name>: <brief description> — started: YYYY-MM-DD
 ```
-Do not touch any other section of the work stream file.
+Create the `## Tasks` section just above `## Notes` if it's missing (work streams created before this change may lack it). No `ended:` field yet — that's appended later when the user reports the task done (see the completion workflow in `notes/templates/task.md`). Do not touch any other section of the work stream file.
 
 #### Update daily log:
 Append to `notes/daily/YYYY-MM-DD.md`:

--- a/.claude/skills/workstream-format.md
+++ b/.claude/skills/workstream-format.md
@@ -23,7 +23,11 @@ Longer description of what this work stream encompasses and its goals.
 - PRs: <!-- links added as PRs are created -->
 
 ## Tasks
-<!-- Populated ONLY by /start-coding — a historical log of coding tasks kicked off for this stream. -->
+<!--
+Coding tasks for this stream. See notes/templates/task.md.
+  - <task-name>: <brief description> — started: YYYY-MM-DD
+  - <task-name>: <brief description> — started: YYYY-MM-DD | ended: YYYY-MM-DD
+-->
 
 ## Notes
 <!-- Prose: decisions, observations, open questions -->
@@ -32,7 +36,16 @@ Longer description of what this work stream encompasses and its goals.
 <!-- Pointers: screenshots, decision docs, external references, linked squawk items -->
 ```
 
-Work streams are a **doc-of-docs**, not a progress tracker. Day-to-day todos live in the single running list at `notes/todos/running.md` (tagged with `workstream: <name>`), NOT in the work stream file itself. The `## Tasks` section is the one exception: `/start-coding` appends a bullet there each time a coding task folder is scaffolded, giving the stream a durable record of the coding sessions that contributed to it. No other skill writes to `## Tasks`.
+Work streams are a **doc-of-docs**, not a progress tracker. Day-to-day todos live in the single running list at `notes/todos/running.md` (tagged with `workstream: <name>`), NOT in the work stream file itself. The `## Tasks` section is the one exception: `/start-coding` appends a bullet there each time a coding task folder is scaffolded, giving the stream a durable record of the coding sessions that contributed to it.
+
+### Task line format
+
+Coding-task lines follow the template at `notes/templates/task.md`. Summary:
+
+- **Open:** `- <task-name>: <brief description> — started: YYYY-MM-DD`
+- **Completed:** `- <task-name>: <brief description> — started: YYYY-MM-DD | ended: YYYY-MM-DD`
+
+`/start-coding` writes the open form. Completion — adding `| ended: YYYY-MM-DD` — happens when the user reports a task done in the chat ("I completed fix-auth-timeout", "wrapped up backflow-audit last Tuesday", etc.). Follow the completion workflow in `notes/templates/task.md` exactly: parse the date phrase, find the matching open bullet, append `| ended: <date>` in place, log it. No skill invocation is required — the template IS the spec.
 
 ## Reading Work Streams
 

--- a/.claude/skills/workstream-format.md
+++ b/.claude/skills/workstream-format.md
@@ -22,6 +22,9 @@ Longer description of what this work stream encompasses and its goals.
 - Jira Epic: [[PROJ-1234]]
 - PRs: <!-- links added as PRs are created -->
 
+## Tasks
+<!-- Populated ONLY by /start-coding — a historical log of coding tasks kicked off for this stream. -->
+
 ## Notes
 <!-- Prose: decisions, observations, open questions -->
 
@@ -29,7 +32,7 @@ Longer description of what this work stream encompasses and its goals.
 <!-- Pointers: screenshots, decision docs, external references, linked squawk items -->
 ```
 
-Work streams are a **doc-of-docs**, not a progress tracker. Todos for a work stream live in the single running list at `notes/todos/running.md` (tagged with `workstream: <name>`), NOT in the work stream file itself.
+Work streams are a **doc-of-docs**, not a progress tracker. Day-to-day todos live in the single running list at `notes/todos/running.md` (tagged with `workstream: <name>`), NOT in the work stream file itself. The `## Tasks` section is the one exception: `/start-coding` appends a bullet there each time a coding task folder is scaffolded, giving the stream a durable record of the coding sessions that contributed to it. No other skill writes to `## Tasks`.
 
 ## Reading Work Streams
 

--- a/docs/migrations/running-todos.md
+++ b/docs/migrations/running-todos.md
@@ -5,8 +5,8 @@ If you started using Eddy before this change, your vault has per-work-stream tod
 ## What changed
 
 - **Todos:** every per-stream file (`notes/todos/<stream>.md`) is replaced by one running list at `notes/todos/running.md`. Each item carries its workstream (and other context) inline.
-- **Work streams:** the `## Tasks` section is removed from the work stream template. `## Notes` stays. A new `## Links & Context` section is added for screenshots, decision docs, and external pointers.
-- **Skills:** `/start-coding` no longer creates todos or writes into the work stream body. `/ingest` now proposes todo items interactively instead of silently writing them.
+- **Work streams:** `## Tasks` stays, but is now populated ONLY by `/start-coding` (a historical log of coding tasks kicked off against the stream). `## Notes` stays. A new `## Links & Context` section is added for screenshots, decision docs, and external pointers.
+- **Skills:** `/start-coding` no longer creates running-list todos — it still appends a line to the work stream's `## Tasks` section. `/ingest` now proposes todo items interactively instead of silently writing them.
 
 See [ROADMAP.md](../../ROADMAP.md) for the rationale.
 
@@ -105,9 +105,8 @@ Do this per stream; keep `notes/todos/.gitkeep` if it exists.
 
 For every `notes/workstreams/<stream>.md`:
 
-1. Delete the `## Tasks` section. If it contained links to task folders that you still care about, move those lines into a new `## Links & Context` section at the bottom of the file (same bullet shape — they're pointers, not prose).
-2. Keep `## Description`, `## Related`, and `## Notes` exactly as they are.
-3. Add `## Links & Context` if it isn't already there, even if empty — future ingests and decision docs will land there.
+1. Keep `## Description`, `## Related`, `## Tasks`, and `## Notes` as they are. `## Tasks` is still a valid section — `/start-coding` writes to it each time a coding task is kicked off. Do NOT edit existing `## Tasks` lines by hand; leave them alone as historical records.
+2. Add `## Links & Context` at the bottom if it isn't already there, even if empty — future ingests and decision docs will land there. Put it AFTER `## Notes`.
 
 **Before:**
 
@@ -129,22 +128,25 @@ Decided at the 03-27 sync to prioritize backflow first.
 ## Related
 - Repos: [[backflow]]
 
+## Tasks
+- fix-auth-timeout: patch retry backoff — started 2026-03-28
+- audit-error-paths: survey across services — started 2026-04-02
+
 ## Notes
 Decided at the 03-27 sync to prioritize backflow first.
 
 ## Links & Context
-- fix-auth-timeout task folder
-- audit-error-paths task folder
+<!-- future screenshots, decision docs, external references land here -->
 ```
 
 ## Step 4 — verify
 
 1. `git grep -n "notes/todos/<" .claude` — should return nothing (no skill still references a per-stream todo file).
-2. `git grep -n "^## Tasks$" notes/workstreams` — should return nothing.
-3. Run `/whats-next`. It should read `running.md`, parse inline fields, and group by workstream without errors.
-4. Run `/daily-plan`. Same expectation — items come from `running.md`.
-5. Check an item off in `running.md`, add `| completed: YYYY-MM-DD`, then run `/recap daily` — the completion should appear.
-6. Run `/new-task` with a throwaway task. Confirm it appends one line to `running.md` and does not create a per-stream file or edit a work stream.
+2. Run `/whats-next`. It should read `running.md`, parse inline fields, and group by workstream without errors.
+3. Run `/daily-plan`. Same expectation — items come from `running.md`.
+4. Check an item off in `running.md`, add `| completed: YYYY-MM-DD`, then run `/recap daily` — the completion should appear.
+5. Run `/new-task` with a throwaway task. Confirm it appends one line to `running.md` and does not create a per-stream file or edit a work stream body.
+6. Run `/start-coding` against a work stream. Confirm it appends a new bullet to that work stream's `## Tasks` section and does NOT write to `running.md`.
 
 If any of those fail, `git diff` the migration and look for items that still carry an old trailer (`— added …` without a pipe) or stray per-stream todo files.
 

--- a/notes/templates/task.md
+++ b/notes/templates/task.md
@@ -1,0 +1,40 @@
+---
+type: coding-task
+---
+
+# Coding Task Line Template
+
+A coding task lives as one line in a work stream's `## Tasks` section. There are exactly two states.
+
+## Open (just started)
+
+```
+- <task-name>: <brief description> — started: YYYY-MM-DD
+```
+
+Written by `/start-coding` when a task folder is scaffolded. `<task-name>` is the kebab-case folder name; `<brief description>` is a short phrase explaining the task.
+
+## Completed
+
+```
+- <task-name>: <brief description> — started: YYYY-MM-DD | ended: YYYY-MM-DD
+```
+
+Produced by appending ` | ended: YYYY-MM-DD` to the open line. The start date never changes. A task can be reopened by removing the `| ended: ...` segment.
+
+## Completion workflow
+
+When the user reports a coding task done — by saying "I completed <task>", "I finished <task>", "<task> is done", "wrapped up <task> last Tuesday", or similar, or by invoking this template explicitly — the agent should:
+
+1. Parse a completion date from the user's phrase (today if unstated; resolve "yesterday", "last Tuesday", "on April 14", etc. against today). If ambiguous, ask.
+2. Find the matching open bullet in a work stream's `## Tasks` section (search by task-name first, then substring on the description). Ask to disambiguate if multiple open tasks match. If the only match is already completed, ask whether to overwrite.
+3. Append ` | ended: YYYY-MM-DD` to that line in place. Don't touch any other section of the work stream file, and don't modify the `started:` date.
+4. Append an entry to today's daily log: `- **HH:MM** — [complete-coding-task] Marked "<task-name>" ended <YYYY-MM-DD> in [[<work-stream>]]`.
+5. Tell the user what line was updated and the task's duration (end − start).
+
+## Rules
+
+- ISO dates only (`YYYY-MM-DD`).
+- Pre-existing lines in the older `started YYYY-MM-DD` form (no colon) should be normalized to `started: YYYY-MM-DD` when they're touched for completion.
+- This template is the source of truth for the line format. `/start-coding` writes the open form; the completion workflow above appends `ended:`.
+- Coding tasks are separate from running-list todos (`notes/todos/running.md`). Don't conflate the two: the running list is day-to-day work, the `## Tasks` section is a historical log of coding sessions per work stream.

--- a/notes/templates/workstream.md
+++ b/notes/templates/workstream.md
@@ -14,6 +14,9 @@ description: "{{description}}"
 - Repos: {{repo_links}}
 - Jira Epic: [[{{jira_epic}}]]
 
+## Tasks
+<!-- Populated ONLY by /start-coding as coding tasks are kicked off. Do not edit by hand. -->
+
 ## Notes
 <!-- Prose: decisions, observations, open questions -->
 

--- a/notes/templates/workstream.md
+++ b/notes/templates/workstream.md
@@ -15,7 +15,11 @@ description: "{{description}}"
 - Jira Epic: [[{{jira_epic}}]]
 
 ## Tasks
-<!-- Populated ONLY by /start-coding as coding tasks are kicked off. Do not edit by hand. -->
+<!--
+Coding tasks started against this stream. See notes/templates/task.md for the line format and completion flow.
+  - <task-name>: <brief description> — started: YYYY-MM-DD
+  - <task-name>: <brief description> — started: YYYY-MM-DD | ended: YYYY-MM-DD
+-->
 
 ## Notes
 <!-- Prose: decisions, observations, open questions -->


### PR DESCRIPTION
Stacked on top of [#20](https://github.com/brian-bell/eddy/pull/20) (Phase A). Parallel to [#21](https://github.com/brian-bell/eddy/pull/21) (due dates) — no conflicts expected.

## Summary

Partial reversal of A2. The \`## Tasks\` section is restored to the workstream template and reference example, sitting between \`## Related\` and \`## Notes\`. \`/start-coding\` writes to it again — and is still the only skill that does.

### Why

A2 dropped \`## Tasks\` to keep workstreams as a pure doc-of-docs. In practice, losing the per-stream historical record of coding sessions cost more than it saved — there was no easy place to see \"what coding tasks have been kicked off against this stream?\" The running list answers day-to-day work, but not that historical view.

The compromise: keep the running list as the one source of day-to-day truth, and let \`/start-coding\` append a durable bullet to \`## Tasks\` at session kickoff. No other skill touches \`## Tasks\`.

### Behavior

When \`/start-coding\` scaffolds a task folder, it appends one line to the matched work stream's \`## Tasks\` section:

\`\`\`
- <task-name>: <brief description> — started YYYY-MM-DD
\`\`\`

If an older workstream file lacks \`## Tasks\`, \`/start-coding\` creates the section just above \`## Notes\`. Nothing else in the workstream body is modified. \`/start-coding\` still does NOT write to \`notes/todos/running.md\` — users add running-list entries via \`/new-task\`.

### Files touched

- \`notes/templates/workstream.md\` — \`## Tasks\` added back.
- \`.claude/skills/workstream-format.md\` — reference example + prose explaining that \`/start-coding\` is the only writer.
- \`.claude/skills/start-coding/SKILL.md\` — restore the Tasks-section write; update the summary line.
- \`docs/migrations/running-todos.md\` — existing \`## Tasks\` sections are preserved rather than stripped; remove the verification step that grepped for their absence; add a new verification step for the \`/start-coding\` → \`## Tasks\` flow.

## Test plan

- [ ] New work streams created from the template include \`## Tasks\`.
- [ ] \`/start-coding\` appends a bullet to the work stream's \`## Tasks\` section in the documented format; no other section is modified.
- [ ] \`/start-coding\` against a work stream file missing \`## Tasks\` (pre-migration format) creates the section above \`## Notes\` and appends the bullet.
- [ ] \`/start-coding\` does NOT write to \`notes/todos/running.md\`.
- [ ] \`/new-task\` still only writes to \`running.md\` — no \`## Tasks\` write.
- [ ] \`/ingest\` does not touch \`## Tasks\`.