### PR TITLE
Add start/end dates to coding tasks via task template

### DIFF
--- a/.claude/skills/start-coding/SKILL.md
+++ b/.claude/skills/start-coding/SKILL.md
@@ -86,11 +86,11 @@ Follow `vault-conventions.md`, `workstream-format.md`, and `daily-log-format.md`
 `/start-coding` does NOT write to `notes/todos/running.md`. If the user wants this task on the running todo list, they can add one with `/new-task`. It DOES append a line to the matched work stream's `## Tasks` section — that section is a historical log of coding tasks started against the stream, and `/start-coding` is the only skill that writes to it.
 
 #### Append to the work stream `## Tasks` section:
-Find the matched work stream file at `notes/workstreams/<stream>.md` and append a bullet to its `## Tasks` section (create the section just above `## Notes` if it is missing — templates written before this change may lack it):
+Find the matched work stream file at `notes/workstreams/<stream>.md` and append a bullet in the open form from `notes/templates/task.md`:
 ```
-- <task-name>: <brief description> — started YYYY-MM-DD
+- <task-name>: <brief description> — started: YYYY-MM-DD
 ```
-Do not touch any other section of the work stream file.
+Create the `## Tasks` section just above `## Notes` if it's missing (work streams created before this change may lack it). No `ended:` field yet — that's appended later when the user reports the task done (see the completion workflow in `notes/templates/task.md`). Do not touch any other section of the work stream file.
 
 #### Update daily log:
 Append to `notes/daily/YYYY-MM-DD.md`:

--- a/.claude/skills/workstream-format.md
+++ b/.claude/skills/workstream-format.md
@@ -23,7 +23,11 @@ Longer description of what this work stream encompasses and its goals.
 - PRs: <!-- links added as PRs are created -->
 
 ## Tasks
-<!-- Populated ONLY by /start-coding — a historical log of coding tasks kicked off for this stream. -->
+<!--
+Coding tasks for this stream. See notes/templates/task.md.
+  - <task-name>: <brief description> — started: YYYY-MM-DD
+  - <task-name>: <brief description> — started: YYYY-MM-DD | ended: YYYY-MM-DD
+-->
 
 ## Notes
 <!-- Prose: decisions, observations, open questions -->
@@ -32,7 +36,16 @@ Longer description of what this work stream encompasses and its goals.
 <!-- Pointers: screenshots, decision docs, external references, linked squawk items -->
 ```
 
-Work streams are a **doc-of-docs**, not a progress tracker. Day-to-day todos live in the single running list at `notes/todos/running.md` (tagged with `workstream: <name>`), NOT in the work stream file itself. The `## Tasks` section is the one exception: `/start-coding` appends a bullet there each time a coding task folder is scaffolded, giving the stream a durable record of the coding sessions that contributed to it. No other skill writes to `## Tasks`.
+Work streams are a **doc-of-docs**, not a progress tracker. Day-to-day todos live in the single running list at `notes/todos/running.md` (tagged with `workstream: <name>`), NOT in the work stream file itself. The `## Tasks` section is the one exception: `/start-coding` appends a bullet there each time a coding task folder is scaffolded, giving the stream a durable record of the coding sessions that contributed to it.
+
+### Task line format
+
+Coding-task lines follow the template at `notes/templates/task.md`. Summary:
+
+- **Open:** `- <task-name>: <brief description> — started: YYYY-MM-DD`
+- **Completed:** `- <task-name>: <brief description> — started: YYYY-MM-DD | ended: YYYY-MM-DD`
+
+`/start-coding` writes the open form. Completion — adding `| ended: YYYY-MM-DD` — happens when the user reports a task done in the chat ("I completed fix-auth-timeout", "wrapped up backflow-audit last Tuesday", etc.). Follow the completion workflow in `notes/templates/task.md` exactly: parse the date phrase, find the matching open bullet, append `| ended: <date>` in place, log it. No skill invocation is required — the template IS the spec.
 
 ## Reading Work Streams
 

--- a/notes/templates/task.md
+++ b/notes/templates/task.md
@@ -1,0 +1,40 @@
+---
+type: coding-task
+---
+
+# Coding Task Line Template
+
+A coding task lives as one line in a work stream's `## Tasks` section. There are exactly two states.
+
+## Open (just started)
+
+```
+- <task-name>: <brief description> — started: YYYY-MM-DD
+```
+
+Written by `/start-coding` when a task folder is scaffolded. `<task-name>` is the kebab-case folder name; `<brief description>` is a short phrase explaining the task.
+
+## Completed
+
+```
+- <task-name>: <brief description> — started: YYYY-MM-DD | ended: YYYY-MM-DD
+```
+
+Produced by appending ` | ended: YYYY-MM-DD` to the open line. The start date never changes. A task can be reopened by removing the `| ended: ...` segment.
+
+## Completion workflow
+
+When the user reports a coding task done — by saying "I completed <task>", "I finished <task>", "<task> is done", "wrapped up <task> last Tuesday", or similar, or by invoking this template explicitly — the agent should:
+
+1. Parse a completion date from the user's phrase (today if unstated; resolve "yesterday", "last Tuesday", "on April 14", etc. against today). If ambiguous, ask.
+2. Find the matching open bullet in a work stream's `## Tasks` section (search by task-name first, then substring on the description). Ask to disambiguate if multiple open tasks match. If the only match is already completed, ask whether to overwrite.
+3. Append ` | ended: YYYY-MM-DD` to that line in place. Don't touch any other section of the work stream file, and don't modify the `started:` date.
+4. Append an entry to today's daily log: `- **HH:MM** — [complete-coding-task] Marked "<task-name>" ended <YYYY-MM-DD> in [[<work-stream>]]`.
+5. Tell the user what line was updated and the task's duration (end − start).
+
+## Rules
+
+- ISO dates only (`YYYY-MM-DD`).
+- Pre-existing lines in the older `started YYYY-MM-DD` form (no colon) should be normalized to `started: YYYY-MM-DD` when they're touched for completion.
+- This template is the source of truth for the line format. `/start-coding` writes the open form; the completion workflow above appends `ended:`.
+- Coding tasks are separate from running-list todos (`notes/todos/running.md`). Don't conflate the two: the running list is day-to-day work, the `## Tasks` section is a historical log of coding sessions per work stream.

--- a/notes/templates/workstream.md
+++ b/notes/templates/workstream.md
@@ -15,7 +15,11 @@ description: "{{description}}"
 - Jira Epic: [[{{jira_epic}}]]
 
 ## Tasks
-<!-- Populated ONLY by /start-coding as coding tasks are kicked off. Do not edit by hand. -->
+<!--
+Coding tasks started against this stream. See notes/templates/task.md for the line format and completion flow.
+  - <task-name>: <brief description> — started: YYYY-MM-DD
+  - <task-name>: <brief description> — started: YYYY-MM-DD | ended: YYYY-MM-DD
+-->
 
 ## Notes
 <!-- Prose: decisions, observations, open questions -->


### PR DESCRIPTION
Stacked on top of [#22](https://github.com/brian-bell/eddy/pull/22) (restore \`## Tasks\`). Merge that one first.

## Summary

Coding tasks (entries in a work stream's \`## Tasks\` section) now carry both a start date and an end date. Introduces \`notes/templates/task.md\` as the single source of truth for the line format and the completion workflow — no new slash command.

## Line format

```
Open:      - <name>: <desc> — started: YYYY-MM-DD
Completed: - <name>: <desc> — started: YYYY-MM-DD | ended: YYYY-MM-DD
```

\`/start-coding\` writes the open form when scaffolding a task folder.

## Completion workflow

When the user tells the agent a coding task is done — in natural language, not via a slash command — the agent:

1. Parses a date phrase from the message (\"last Tuesday\", \"yesterday\", \"on April 14\", ISO date) or defaults to today. Ambiguous phrases prompt for clarification.
2. Finds the matching open bullet in a work stream's \`## Tasks\` section (by task-name first, then substring on description). Asks to disambiguate on multiple matches.
3. Appends \` | ended: YYYY-MM-DD\` to that line in place. Nothing else in the work stream file changes.
4. Adds a daily-log entry.
5. Reports back with the rewritten line and task duration.

The template lays out these steps explicitly — the agent reads it and follows. Pre-existing lines in the older \`started YYYY-MM-DD\` form (no colon) get normalized to \`started: YYYY-MM-DD\` when they're touched for completion.

## Files touched

- \`notes/templates/task.md\` (new) — format + completion workflow, the source of truth.
- \`.claude/skills/workstream-format.md\` — reference the template; drop prose claim that a dedicated skill handles completion.
- \`.claude/skills/start-coding/SKILL.md\` — point at the template when writing the open form.
- \`notes/templates/workstream.md\` — update the \`## Tasks\` comment to reference the template.

## Test plan

- [ ] \`/start-coding\` writes \`— started: YYYY-MM-DD\` (with the colon) to the matched work stream's \`## Tasks\` section.
- [ ] \"I completed fix-auth-timeout\" → the matching open bullet gets \` | ended: <today>\` appended; daily log updated.
- [ ] \"I finished backflow-audit last Tuesday\" → the end date resolves to the correct prior Tuesday.
- [ ] Ambiguous phrases (e.g. \"I completed the timeout work\" when two tasks contain \"timeout\") prompt for disambiguation before writing.
- [ ] Pre-PR lines in the older \`— started YYYY-MM-DD\` form are normalized to \`— started: YYYY-MM-DD | ended: YYYY-MM-DD\` when completion is processed.
- [ ] \`started:\` dates are never modified by the completion flow.
- [ ] No other section of the work stream file is touched during completion.