### PR TITLE
Require fresh timestamp immediately before each daily log write

### DIFF
--- a/.claude/skills/daily-log-format.md
+++ b/.claude/skills/daily-log-format.md
@@ -63,4 +63,6 @@ Use these prefixes in brackets:
 
 If the daily log for today doesn't exist when a skill needs to append to it, create it using the template above, then append the entry.
 
-Use the current time from the system when creating timestamps.
+## Timestamps
+
+Fetch the current system time **immediately before writing each Activity Log entry** — run `date +%H:%M` right before the write and use that value verbatim. Do NOT reuse a timestamp captured earlier in the conversation (e.g., from session start, an earlier tool call, or the skill's first step). Long-running skills, tool chains, and waits can drift a cached timestamp by many minutes, which corrupts the chronological spine the daily log is meant to provide.


### PR DESCRIPTION
## Summary
- Strengthens `daily-log-format.md` so skills fetch a fresh `date +%H:%M` right before writing each Activity Log entry instead of reusing a value captured earlier.
- Adds a dedicated **Timestamps** section that explicitly forbids reusing cached timestamps from session start, earlier tool calls, or the skill's first step.

## Motivation
Skills sometimes stamp daily log entries with the time the conversation started (or some earlier tool call) rather than the moment they actually write the entry. Long-running skills, tool chains, and waits can drift a cached timestamp by many minutes, which corrupts the chronological spine the Activity Log is meant to provide. The old line ("Use the current time from the system when creating timestamps") was too weak — it didn't say *when* to fetch the time.

Stacked on #20.

## Test plan
- [ ] Re-read `.claude/skills/daily-log-format.md` and confirm the new Timestamps section is clear about fetching time immediately before the write.
- [ ] Run a skill that touches the daily log (e.g. `/ingest`, `/idea`, `/new-task`) after a multi-minute pause in the session and verify the logged timestamp matches the actual wall-clock write time.