### PR TITLE
Archive completed todos in dated completed.md; recap + whats-next read it

### DIFF
--- a/.claude/skills/recap/SKILL.md
+++ b/.claude/skills/recap/SKILL.md
@@ -24,8 +24,8 @@ Check if the user specified "daily" or "weekly" in their message. Default to "da
 - Read `notes/daily/YYYY-MM-DD.md` — all activity log entries
 
 **Completed Todos:**
-- Read `notes/todos/running.md` — find items checked off (`- [x]`) whose `completed:` field (or nearby date) matches today.
-- Use `git diff notes/todos/running.md` to detect checkbox flips from `[ ]` to `[x]` since the last commit / start of day.
+- Read `notes/todos/completed.md` — find the `## YYYY-MM-DD` heading for today and collect every `- [x]` line under it (until the next `## ` heading). Each line carries inline fields (`workstream`, `added`, `completed`, …); use `workstream` for grouping in the recap.
+- If `notes/todos/running.md` contains stray `- [x]` lines (manual checkbox flips not yet migrated), include those whose `completed:` field matches today and migrate them into `completed.md` as part of this pass per `vault-conventions.md`.
 
 **PR Activity:**
 - Read files in `notes/prs/` modified today (check file modification time or git diff)
@@ -45,7 +45,11 @@ Check if the user specified "daily" or "weekly" in their message. Default to "da
 - Read files in `notes/workstreams/` modified today
 
 #### For Weekly Recap:
-Same sources but scan across the week's dates. Use `git log --since` to find modified files.
+
+Same sources, scanned across the week:
+
+- **Completed Todos:** read every `## YYYY-MM-DD` heading in `notes/todos/completed.md` from this week's Monday through today (inclusive). Aggregate the `- [x]` lines under each heading.
+- For other sources (daily logs, PRs, squawk, ideas, tickets, work streams), use `git log --since` to find modified files within the week.
 
 ### 3. Generate Recap
 

--- a/.claude/skills/vault-conventions.md
+++ b/.claude/skills/vault-conventions.md
@@ -73,6 +73,7 @@ Every skill that creates or modifies vault data MUST append a summary entry to t
 - Ticket notes: `<system>-<KEY>.md` (e.g., `jira-BACK-1234.md`)
 - Work streams: `<work-stream-name>.md` (e.g., `error-handling-overhaul.md`)
 - Todos: a single running list at `notes/todos/running.md` (no per-stream todo files)
+- Completed todos: archived in `notes/todos/completed.md`, organized by `## YYYY-MM-DD` headings (newest first)
 - Recaps: `YYYY-MM-DD.md` for daily, `week-YYYY-WW.md` for weekly
 
 ## Running Todo List
@@ -92,7 +93,7 @@ All open todos live in one file, `notes/todos/running.md`. Each item is a Markdo
 | `due` | optional | ISO date (YYYY-MM-DD) by which the item should be done. If omitted, the item is always eligible for today's plan (no deadline). |
 | `source` | optional | Origin of the item: `help-request`, `followup`, `meeting-action`, `self`. Populated fully in Phase B1 — omit if unknown for now. |
 | `stakeholder` | optional | `@handle` of the person the item primarily serves (requester for help-requests, attendee for meeting actions, etc.) |
-| `completed` | on completion | ISO date when the checkbox is ticked. Append to the same trailing segment. |
+| `completed` | on completion | ISO date when the checkbox is ticked. Append to the same trailing segment, then move the line into `completed.md` (see "Completing items"). |
 
 ### Rules
 
@@ -101,9 +102,42 @@ All open todos live in one file, `notes/todos/running.md`. Each item is a Markdo
 - Put `[[wikilinks]]` and `#tags` in the description portion, not the fields.
 - Skills that add items MUST populate `workstream` and `added` at minimum.
 
+### Completing items
+
+Completion is conversational — the user says "I finished X" / "wrapped up Y" and the agent:
+
+1. Finds the matching `- [ ]` line in `notes/todos/running.md`.
+2. Flips the box to `- [x]` and appends ` | completed: YYYY-MM-DD` (today, unless the user gave a different date).
+3. Removes that line from `running.md`.
+4. Appends it to `notes/todos/completed.md` under a `## YYYY-MM-DD` heading for today, creating that heading at the top of the file if it doesn't already exist (newest day first).
+5. Writes the standard `[complete-todo]` action entry to today's daily log.
+
+Completed items NEVER linger in `running.md`. The move is immediate, not a deferred sweep. If a user manually flips a `[ ]` to `[x]` in `running.md` (in their editor) without telling the agent, the next skill that reads `running.md` should treat any `[x]` lines it finds there as stragglers and migrate them on encounter.
+
 ### Snoozing
 
 To snooze an item, edit its `due` field to a later date. That's the whole mechanism — there is no separate snooze state. An item with `due: 2026-04-20` is simply not eligible for today's plan until that date arrives (see `/daily-plan` for the filtering rules). To defer indefinitely, remove the `due` field — but note that undated items are always eligible; if you want to hide something from the active plan, push the `due` date out instead.
+
+## Completed Todos Archive
+
+Completed running-list items live in `notes/todos/completed.md`. The file is grouped by completion date — one `## YYYY-MM-DD` heading per day, newest first, each followed by the `- [x]` lines that completed on that date:
+
+```markdown
+## 2026-04-17
+- [x] Audit timeout paths in backflow [[backflow-142]] — workstream: error-handling-overhaul | added: 2026-03-28 | completed: 2026-04-17
+- [x] Document retry policy — workstream: error-handling-overhaul | added: 2026-04-02 | completed: 2026-04-17
+
+## 2026-04-15
+- [x] Land Linear ticket parity — workstream: eddy-development | added: 2026-04-08 | completed: 2026-04-15
+```
+
+Rules:
+
+- Each item keeps its full pipe-separated field set; `completed: YYYY-MM-DD` matches the heading it sits under.
+- Insert new completions at the TOP of the relevant day's section (most recent completion first within a day).
+- If today's heading doesn't exist yet, add it as the new top section before any older days.
+- Never reorder existing days; just prepend.
+- Skills only write to this file in two cases: (a) the user marks a running-list item complete, or (b) a skill encounters a straggler `[x]` line in `running.md` and migrates it here per the "Completing items" rules. `/recap` and `/whats-next` otherwise read it as context.
 
 ## Work Stream Sovereignty
 

--- a/.claude/skills/whats-next/SKILL.md
+++ b/.claude/skills/whats-next/SKILL.md
@@ -108,12 +108,34 @@ After generating the ranked list, check if any ideas relate to the surfaced work
 - If no ideas are relevant, do not show this section at all
 - Keep it brief — title and related stream link, nothing more
 
-### 5. Offer Actions
+### 5. Today's Wins (momentum footer)
+
+After the prioritized items (and any Idea Sparks), append a brief **Today's Wins** section that surfaces what the user already finished today. This is for momentum, not ranking — it lives at the very bottom and stays small.
+
+1. Read `notes/todos/completed.md` and find the `## YYYY-MM-DD` heading for today.
+2. Collect the `- [x]` lines under it (until the next `## ` heading). If the heading doesn't exist, skip the section entirely.
+3. Render the count and up to the top 3 items (most recently appended — i.e., the ones at the top of today's section):
+
+```
+### Today's Wins
+4 completed today
+- ✓ Audit timeout paths in backflow ([[Error Handling Overhaul]])
+- ✓ Document retry policy ([[Error Handling Overhaul]])
+- ✓ Land Linear ticket parity ([[Eddy Development]])
+```
+
+Rules:
+- ONLY today's section. Do not pull from earlier days.
+- If today's section is empty or missing, omit the entire footer.
+- Keep it to count + at most 3 items. Strip the inline fields when rendering — show description and `[[workstream]]` only.
+- Do not score or rank these — they're already done.
+
+### 6. Offer Actions
 
 After presenting the list, ask:
 - "Want to start on any of these? I can help with PR feedback, task setup, or Jira updates."
 
-### 6. Update Daily Log
+### 7. Update Daily Log
 
 Append to `notes/daily/YYYY-MM-DD.md`:
 ```

--- a/docs/migrations/completed-todos.md
+++ b/docs/migrations/completed-todos.md
@@ -1,0 +1,86 @@
+# Completed-Todos Migration Guide
+
+If you adopted the running-todos layout (see [`running-todos.md`](./running-todos.md)) before this change, your `notes/todos/running.md` likely contains both open `- [ ]` and completed `- [x]` items mixed together. This change splits completions into a dated archive at `notes/todos/completed.md`. This guide walks you through the one-time migration.
+
+## What changed
+
+- **New file:** `notes/todos/completed.md` is the durable archive of completed todos. Items are grouped by `## YYYY-MM-DD` headings (newest day first). Each day's section contains the `- [x]` lines that finished on that date.
+- **Immediate move on completion:** when the user says "I finished X", the agent now flips the box, appends `| completed: YYYY-MM-DD`, removes the line from `running.md`, and prepends it to today's heading in `completed.md`. Completed items NEVER linger in `running.md`.
+- **`/recap` daily** reads only today's heading in `completed.md`. **`/recap` weekly** reads every heading from this week's Monday through today.
+- **`/whats-next`** appends a tiny "Today's Wins" footer driven by today's heading in `completed.md` (count + top 3) for momentum context. It does NOT use earlier days.
+
+See [`vault-conventions.md`](../../.claude/skills/vault-conventions.md) for the full spec, including the "Completing items" and "Completed Todos Archive" sections.
+
+## Before you start
+
+1. **Commit your vault.** `git add -A && git commit -m "pre completed-todos snapshot"` so you can roll back if needed.
+2. **Pull the latest Eddy skills.** `git pull` in whichever directory hosts the Eddy `.claude/` skills, so the updated templates and skill docs are available.
+
+## Step 1 — create `completed.md`
+
+Seed the file from the template:
+
+```sh
+cp notes/templates/completed.md notes/todos/completed.md
+```
+
+Open it and delete the example-comment block if you prefer a clean file. The frontmatter and H1 should stay.
+
+## Step 2 — move existing `[x]` items out of `running.md`
+
+For every `- [x] …` line in `notes/todos/running.md`:
+
+1. Read the line's `completed: YYYY-MM-DD` field. If the line lacks `completed:`, set it to today (or the date you finished it, if you remember).
+2. In `completed.md`, ensure a `## YYYY-MM-DD` heading exists for that date. If not, insert it in the correct chronological position (newest at top).
+3. Move the `- [x]` line under that heading. Remove it from `running.md`.
+
+### Semi-automated split
+
+This `awk` one-liner partitions an existing `running.md` into "open lines stay" and "completed lines route by date." Review its output before overwriting either file.
+
+```sh
+awk '
+  /^- \[x\]/ {
+    if (match($0, /completed: ([0-9]{4}-[0-9]{2}-[0-9]{2})/, m)) {
+      print $0 > "completed-by-date/" m[1] ".tmp"
+    } else {
+      print $0 > "completed-by-date/UNKNOWN.tmp"
+    }
+    next
+  }
+  { print }   # everything else (including frontmatter, header, comments, open items) stays
+' notes/todos/running.md > notes/todos/running.new.md
+```
+
+Then assemble `completed.md` by concatenating the date-bucket files in reverse chronological order, prepending each with `## <date>` and a blank line. Hand-fix any items that landed in `UNKNOWN.tmp` (they had no `completed:` field).
+
+When the result looks right:
+
+```sh
+mv notes/todos/running.new.md notes/todos/running.md
+```
+
+## Step 3 — verify
+
+1. `notes/todos/running.md` should contain ZERO `- [x]` lines:
+   ```sh
+   grep -c '^- \[x\]' notes/todos/running.md   # expect: 0
+   ```
+2. `notes/todos/completed.md` should have one `## YYYY-MM-DD` heading per distinct completion date, and the lines under each heading should all carry that exact `completed:` value:
+   ```sh
+   grep -c '^- \[x\]' notes/todos/completed.md
+   ```
+3. Run `/recap daily`. The "Completed" section should show today's items pulled from `completed.md` (and nothing from earlier days).
+4. Run `/recap weekly`. The "Completed" section should aggregate items from this week's Monday → today across `completed.md`'s headings.
+5. Run `/whats-next`. If you completed anything today, you should see a small "Today's Wins" footer at the bottom; otherwise the footer should be absent.
+6. Tell the agent "I finished `<an open todo from running.md>`". Confirm the line disappears from `running.md` and appears at the top of today's `## YYYY-MM-DD` section in `completed.md` (a new heading is created if today wasn't there yet).
+
+## Rollback
+
+Everything is in git:
+
+```sh
+git reset --hard <pre-migration commit>
+```
+
+Then pin the Eddy skill repo to a pre-migration commit until you're ready to retry.

--- a/docs/migrations/running-todos.md
+++ b/docs/migrations/running-todos.md
@@ -16,6 +16,8 @@ If you started using Eddy before this change, your vault has per-work-stream tod
 
 See [ROADMAP.md](../../ROADMAP.md) for the rationale.
 
+> **Note:** completed items have since been split into a separate dated archive at `notes/todos/completed.md`. After finishing this migration, follow [`completed-todos.md`](./completed-todos.md) to move any `- [x]` lines out of `running.md`.
+
 ## Before you start
 
 1. **Commit your vault.** `git add -A && git commit -m "pre running-todos snapshot"` in the vault repo so you can roll back if needed.

--- a/notes/templates/completed.md
+++ b/notes/templates/completed.md
@@ -1,0 +1,17 @@
+---
+type: completed-todos
+---
+
+# Completed Todos
+
+<!--
+Archive of completed todo items. When the user marks a running-list item done
+("I finished X"), the agent immediately moves the line out of running.md and
+appends it under today's date heading here. Newest day first.
+
+Format:
+  ## YYYY-MM-DD
+  - [x] <task description> [[optional-link]] — workstream: <name> | added: YYYY-MM-DD | completed: YYYY-MM-DD
+
+See .claude/skills/vault-conventions.md for the full spec.
+-->

--- a/notes/templates/todo.md
+++ b/notes/templates/todo.md
@@ -14,7 +14,9 @@ Format:
 Due date is optional. If omitted, the item is always eligible for today's plan.
 Snooze by editing `due` to a later date.
 
-On completion, append:  | completed: YYYY-MM-DD
+On completion the line is moved immediately out of this file and into
+`notes/todos/completed.md` under a `## YYYY-MM-DD` heading for today.
+Completed items never linger here.
 
 See .claude/skills/vault-conventions.md for the full spec.
 -->


### PR DESCRIPTION
## Summary

Completed running-list items now move out of `running.md` immediately on completion into a dedicated archive at `notes/todos/completed.md`, organized by `## YYYY-MM-DD` headings (newest day first). The flip, field append, removal, archive prepend, and daily-log entry are one conversational unit — no deferred sweep, no `[x]` line ever lingering in `running.md`.

`/recap` and `/whats-next` read the archive as their source of truth for completion data:

- **`/recap daily`** reads only today's heading in `completed.md`.
- **`/recap weekly`** reads every heading from this week's Monday through today.
- **`/whats-next`** appends a small "Today's Wins" footer (count + top 3) driven by today's heading. Omitted entirely when nothing is done yet.

## Changes

- **New template** `notes/templates/completed.md` (frontmatter + format-comment block)
- **`vault-conventions.md`** gains a "Completing items" subsection (5-step move flow) and a top-level "Completed Todos Archive" section describing the per-day shape and prepend rules
- **`/recap` SKILL.md** — daily and weekly Completed-Todos sources rewritten to read `completed.md`; straggler `[x]` lines in `running.md` are migrated on encounter
- **`/whats-next` SKILL.md** — adds a "Today's Wins" momentum footer, gated on today's section being non-empty
- **`notes/templates/todo.md`** — header comment updated to point at the immediate-move semantics
- **`docs/migrations/completed-todos.md`** — new migration guide with semi-automated split, verify steps, and rollback
- **`docs/migrations/running-todos.md`** — cross-reference appended

## Stacking

Based on `claude/suspicious-mclaren-dd66c7` (PR #20). Will rebase / re-target to `main` once #20 lands.

## Test plan

- [ ] Verify `/recap daily` ignores yesterday's `## 2026-04-NN` heading and only surfaces today's items
- [ ] Verify `/recap weekly` aggregates Monday→today across all matching `## YYYY-MM-DD` headings
- [ ] Verify `/whats-next` shows the "Today's Wins" footer when today's heading is non-empty, and hides it when absent
- [ ] Tell the agent "I finished `<an open todo>`" and confirm: the line disappears from `running.md`, today's heading in `completed.md` is created (if missing) and the line is prepended, and a `[complete-todo]` entry is appended to today's daily log
- [ ] Manually flip a `[ ]` to `[x]` in `running.md` (no `completed:` field), then run `/recap` — confirm the straggler is migrated into `completed.md` under today's heading
- [ ] Walk an existing vault through `docs/migrations/completed-todos.md` end-to-end and confirm `running.md` ends up with zero `[x]` lines