### PR TITLE
Slice 1: scaffold JOURNAL.md at task creation

### DIFF
--- a/.claude/skills/new-task/SKILL.md
+++ b/.claude/skills/new-task/SKILL.md
@@ -74,6 +74,7 @@ Then match the task to a work stream:
    <List of cloned repos with their roles>
 
    ## References
+   - Task journal: `./JOURNAL.md` (per-task log; `/checkpoint` rewrites the state header and appends log entries)
    - Work stream: `<workflow-repo>/notes/workstreams/<stream>.md`
    - Running todos: `<workflow-repo>/notes/todos/running.md` (filter by `workstream: <stream>`)
    - Daily log: `<workflow-repo>/notes/daily/`
@@ -86,6 +87,8 @@ Then match the task to a work stream:
    ```
 
    If `AGENTS.md` already exists and is not already that symlink, ask the user before replacing it.
+
+7. Create `<dev-dir>/<task-name>/JOURNAL.md` from `notes/templates/journal.md`, substituting `{{task}}` with the kebab-case task name, `{{workstream}}` with the matched work stream name, and `{{created}}` with today's date (`YYYY-MM-DD`). The rest of the template (state header, empty `## Log`) is written through unchanged. The journal stays local to the task folder — it is not copied into the vault. If `JOURNAL.md` already exists in the folder, leave it alone rather than overwriting.
 
 #### 4b. Non-Coding Mode
 
@@ -129,7 +132,7 @@ Create the `## Tasks` section just above `## Notes` if it's missing. No `ended:`
 
 Tell the user:
 
-- **Coding mode:** task folder location, what was cloned, the `CLAUDE.md` + `AGENTS.md` symlink, the work stream `## Tasks` bullet appended (quote the line), the daily log entry, and how to resume (`cd <folder>` and launch Claude Code or Codex).
+- **Coding mode:** task folder location, what was cloned, the `CLAUDE.md` + `AGENTS.md` symlink, the scaffolded `JOURNAL.md`, the work stream `## Tasks` bullet appended (quote the line), the daily log entry, and how to resume (`cd <folder>` and launch Claude Code or Codex).
 - **Non-coding mode:** the captured task name, work stream, and output type; the work stream `## Tasks` bullet (quote the line); the daily log entry; and a reminder that the output file wasn't pre-created — the user is expected to produce it themselves.
 
 ## Important Rules

--- a/notes/templates/journal.md
+++ b/notes/templates/journal.md
@@ -1,0 +1,33 @@
+---
+type: task-journal
+task: {{task}}
+workstream: {{workstream}}
+created: {{created}}
+---
+
+# Journal: {{task}}
+
+A durable per-task log for work on this task. Co-located with the task folder
+so it travels with the cloned repos and stays close to the work.
+
+- The state header below is **rewritten in place** by `/checkpoint` and (later)
+  by the `SessionStart`/`SessionEnd` hooks. Last-write-wins.
+- The `## Log` section is **append-only** (newest at the bottom). Two entry
+  types: `[session]` (written by hooks) and `[checkpoint]` (written by the
+  `/checkpoint` skill). Each entry starts with an ISO datetime and a one-line
+  reason or title.
+
+## Current State
+<!-- What's the latest understanding of where this task stands? -->
+
+## Next Steps
+<!-- What's the next thing to pick up? -->
+
+## Open Questions
+<!-- What's unresolved and needs a decision or lookup? -->
+
+## Blockers
+<!-- What's preventing forward progress right now? -->
+
+## Log
+<!-- Append-only. Newest entries at the bottom. -->


### PR DESCRIPTION
Closes #29 (part of PRD #28).

## Summary
- New `notes/templates/journal.md`: frontmatter + state header (Current State / Next Steps / Open Questions / Blockers) + empty append-only `## Log`.
- `/new-task` coding mode now writes `JOURNAL.md` into the task folder from that template and references it in the task folder's `CLAUDE.md`.
- Non-coding mode, clones, `AGENTS.md` symlink, `## Tasks` bullet, and daily-log append — all unchanged (preserves user stories 18 and 24).

## Stack
This is the base of a 7-PR stack against PRD #28. Slice 2 will branch from here.

## Test plan
- [ ] Inspect `notes/templates/journal.md` — frontmatter, four state sections, empty `## Log`
- [ ] Run `/new-task` against a sample work stream, coding mode → confirm `JOURNAL.md` scaffolded with task/workstream/created filled in
- [ ] Same run → confirm `CLAUDE.md` in the task folder references `./JOURNAL.md`
- [ ] Same run → confirm `AGENTS.md` symlink, repo clones, `## Tasks` bullet, and daily-log entry all still land as pre-PRD
- [ ] Run `/new-task` in non-coding mode → confirm no `JOURNAL.md` created