### PR TITLE
Slice 2: /checkpoint skill + Module A + bats harness

### DIFF
--- a/.claude/hooks/journal-ops.py
+++ b/.claude/hooks/journal-ops.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Module A — journal file operations.
+
+Deterministic parse/rewrite of a task-folder JOURNAL.md. Three subcommands:
+
+  journal-ops.py read-state <path>
+  journal-ops.py write-state <path>   # reads new state from stdin
+  journal-ops.py append-log <path>    # reads log entry from stdin
+
+Contract (see notes/templates/journal.md and PRD #28):
+  - The state region is the text from the first `## Current State` heading
+    up to (but not including) the `## Log` heading. read-state and
+    write-state operate on that region.
+  - The `## Log` section is append-only. append-log adds an entry at the
+    end. If `## Log` is missing, it is created at the end of the file.
+  - Frontmatter and any intro prose before the state region are always
+    preserved.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+STATE_HEADINGS = (
+    "## Current State",
+    "## Next Steps",
+    "## Open Questions",
+    "## Blockers",
+)
+LOG_HEADING = "## Log"
+
+
+def split_file(text: str) -> tuple[str, str, str]:
+    """Return (prefix, state, log) parts of the journal text.
+
+    - prefix: everything before the first state heading (frontmatter + intro).
+    - state:  from the first state heading up to (but not including) `## Log`,
+              or end-of-file if `## Log` is absent.
+    - log:    from `## Log` to end of file, or empty string if absent.
+
+    If no state heading is present, state is empty and prefix covers the
+    pre-log text.
+    """
+    lines = text.splitlines(keepends=True)
+
+    state_start = None
+    log_start = None
+    for i, line in enumerate(lines):
+        stripped = line.rstrip("\n")
+        if state_start is None and stripped in STATE_HEADINGS:
+            state_start = i
+        if stripped == LOG_HEADING:
+            log_start = i
+            break
+
+    if state_start is None:
+        # No state region. Split prefix/log at log_start if present.
+        if log_start is None:
+            return "".join(lines), "", ""
+        return "".join(lines[:log_start]), "", "".join(lines[log_start:])
+
+    end = log_start if log_start is not None else len(lines)
+    prefix = "".join(lines[:state_start])
+    state = "".join(lines[state_start:end])
+    log = "".join(lines[end:]) if log_start is not None else ""
+    return prefix, state, log
+
+
+def read_state(path: Path) -> str:
+    _, state, _ = split_file(path.read_text())
+    return state
+
+
+def write_state(path: Path, new_state: str) -> None:
+    prefix, _, log = split_file(path.read_text())
+
+    # Normalize new_state so we control the trailing separator between
+    # the state region and the log section.
+    new_state = new_state.rstrip("\n")
+    if new_state:
+        new_state += "\n\n"
+
+    if not log:
+        # No existing Log section — create one at the end.
+        log = LOG_HEADING + "\n<!-- Append-only. Newest entries at the bottom. -->\n"
+
+    # Ensure prefix ends with exactly one trailing newline before state.
+    if prefix and not prefix.endswith("\n"):
+        prefix += "\n"
+    if prefix and not prefix.endswith("\n\n") and new_state:
+        prefix += "\n"
+
+    path.write_text(prefix + new_state + log)
+
+
+def append_log(path: Path, entry: str) -> None:
+    text = path.read_text()
+    entry = entry.rstrip("\n") + "\n"
+
+    if LOG_HEADING not in text:
+        # Create the Log section at the end.
+        if not text.endswith("\n"):
+            text += "\n"
+        if not text.endswith("\n\n"):
+            text += "\n"
+        text += LOG_HEADING + "\n<!-- Append-only. Newest entries at the bottom. -->\n\n"
+        text += entry
+        path.write_text(text)
+        return
+
+    # Log section exists — append entry at the end of the file, separated
+    # from whatever came before by a blank line.
+    if not text.endswith("\n"):
+        text += "\n"
+    if not text.endswith("\n\n"):
+        text += "\n"
+    text += entry
+    path.write_text(text)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(
+            "usage: journal-ops.py {read-state|write-state|append-log} <path>",
+            file=sys.stderr,
+        )
+        return 2
+
+    cmd, raw_path = argv[1], argv[2]
+    path = Path(raw_path)
+
+    if cmd == "read-state":
+        if not path.exists():
+            print(f"journal-ops: no such file: {path}", file=sys.stderr)
+            return 1
+        sys.stdout.write(read_state(path))
+        return 0
+
+    if cmd == "write-state":
+        if not path.exists():
+            print(f"journal-ops: no such file: {path}", file=sys.stderr)
+            return 1
+        write_state(path, sys.stdin.read())
+        return 0
+
+    if cmd == "append-log":
+        if not path.exists():
+            print(f"journal-ops: no such file: {path}", file=sys.stderr)
+            return 1
+        append_log(path, sys.stdin.read())
+        return 0
+
+    print(f"journal-ops: unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/skills/checkpoint/SKILL.md
+++ b/.claude/skills/checkpoint/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: checkpoint
+description: Checkpoint a task by rewriting the task folder's JOURNAL.md state header and appending a log entry. Use after significant events — decisions, pivots, blockers, end-of-session. Pass --promote to also add a dated line to the work stream's Notes section.
+---
+
+# Checkpoint
+
+Capture the current state of work in the task folder's `JOURNAL.md`, so the
+agent can resume cleanly next time and the workstream can (optionally)
+inherit a pointer back to what just happened.
+
+## When to use
+
+- The user (or agent) made a significant decision or pivot.
+- A blocker appeared or got resolved.
+- A session is wrapping up and the agent wants to leave a clean handoff.
+- The user says something like "checkpoint", "note this in the journal",
+  or "let's mark where we are".
+- With `--promote`: the moment is worth surfacing in the work stream
+  (e.g., a milestone, a durable decision, a mid-task insight).
+
+## Preconditions
+
+This skill operates on the current working directory as a task folder.
+
+- Task folder := a directory containing `CLAUDE.md` (scaffolded by
+  `/new-task`) and a `JOURNAL.md`.
+- If no `JOURNAL.md` is present, fall through to the **Init path** below.
+
+## Process
+
+### 1. Detect the task folder and journal
+
+1. Check `$PWD` for `JOURNAL.md`.
+2. If present, read it:
+   - Parse frontmatter fields `task`, `workstream`, `created`.
+   - Parse the current state header using Module A:
+     ```sh
+     <workflow-repo>/.claude/hooks/journal-ops.py read-state JOURNAL.md
+     ```
+3. If absent, go to the **Init path** in step 5.
+
+### 2. Rewrite the state header
+
+Based on the current conversation — recent tool calls, files touched,
+decisions, and what's next — compose a new state region with these four
+sections (in this order, all four always present, even if empty):
+
+```markdown
+## Current State
+<1–4 sentences on where the task actually stands right now>
+
+## Next Steps
+- <concrete next action>
+- <next action>
+
+## Open Questions
+- <unresolved question or decision needed>
+
+## Blockers
+- <what is blocking progress, or "None">
+```
+
+Do NOT invent content. If a section has nothing new, carry forward what's
+already there (or leave it empty). The goal is truthful state, not
+verbose state.
+
+Write it in with Module A:
+
+```sh
+<workflow-repo>/.claude/hooks/journal-ops.py write-state JOURNAL.md < new-state
+```
+
+### 3. Append a `[checkpoint]` log entry
+
+Append an entry that records the checkpoint moment. Format:
+
+```markdown
+### [checkpoint] <ISO-datetime> — <one-line reason>
+
+<2–4 sentence body: what changed since the last entry, what this
+checkpoint marks, what's explicitly deferred or decided>
+```
+
+- `<ISO-datetime>` — fetch fresh via `date -u +%Y-%m-%dT%H:%M:%SZ` **immediately**
+  before writing. Do not reuse a cached timestamp.
+- `<one-line reason>` — what this checkpoint is for (e.g., "decided on
+  retry-with-backoff", "blocked on staging access", "end of session").
+- Body — facts, not recap.
+
+Append it with Module A:
+
+```sh
+<workflow-repo>/.claude/hooks/journal-ops.py append-log JOURNAL.md < entry
+```
+
+### 4. Optional: `--promote`
+
+If the user invoked `/checkpoint --promote` (or said something like "note
+this in the workstream"), additionally propose a single dated line for
+the **work stream's `## Notes` section**:
+
+```markdown
+- YYYY-MM-DD — <short phrase, 10–20 words>. See [[<task-name>]] journal.
+```
+
+**Draft → show → write on approval:**
+
+1. Load `notes/workstreams/<workstream>.md`.
+2. Compose the line (one bullet, one date, links back to the task folder
+   name if helpful).
+3. Show the draft line to the user and ask for explicit approval:
+   > "I'll append this to `notes/workstreams/<workstream>.md` under `## Notes`:
+   > `<line>`. OK?"
+4. Only on approval, append the line to the `## Notes` section of the
+   workstream file. Do not touch any other section.
+5. If the user rejects, skip the workstream write. Still do steps 2–3
+   (state + log) — `--promote` is additive.
+
+This follows eddy's "never auto-modify work stream files without explicit
+user confirmation" rule (see `vault-conventions.md`).
+
+### 5. Init path (no `JOURNAL.md` present)
+
+If the current folder has no `JOURNAL.md`, offer to initialize one:
+
+> "No `JOURNAL.md` found in this folder. Initialize one from
+> `<workflow-repo>/notes/templates/journal.md` so future `/checkpoint`
+> and hook runs have something to write to? (y/N)"
+
+On yes:
+
+1. Read the workstream/task from the folder's `CLAUDE.md` if present (the
+   `## Work Stream` line and the folder name), otherwise ask the user.
+2. Copy the template to `./JOURNAL.md`, substituting `{{task}}`,
+   `{{workstream}}`, and `{{created}}` (today's date).
+3. Proceed with steps 2–3 as normal.
+
+On no: stop silently.
+
+Hook installation (`SessionStart`/`SessionEnd`) is handled in a later
+slice of PRD #28 and will extend this init path.
+
+### 6. Append a daily log entry
+
+Append to `notes/daily/YYYY-MM-DD.md` Activity Log:
+
+```markdown
+- **HH:MM** — [checkpoint] Checkpointed "<task-name>" → [[<workstream>]]
+```
+
+If `--promote` was accepted:
+
+```markdown
+- **HH:MM** — [checkpoint] Checkpointed "<task-name>" and promoted note to [[<workstream>]]
+```
+
+Fetch `date +%H:%M` fresh per the daily-log rule.
+
+### 7. Summarize
+
+Tell the user:
+- The new state header (quote its `## Current State` and `## Next Steps` lines).
+- The one-line reason of the appended log entry.
+- Whether `--promote` landed anything in the work stream.
+
+## Important rules
+
+- **NEVER write to `notes/todos/running.md`.** The journal is private to
+  the task; the running list stays under manual curation.
+- **Last-write-wins on the state header** is acceptable. The `## Log`
+  section is append-only; multiple sessions writing simultaneously will
+  not collide on entries (they stack) but may race on the state header.
+  That's OK for solo use per PRD #28.
+- **Workstream writes require user approval**, always (even for a
+  one-line append).
+- **Timestamps must be fetched fresh**: ISO datetime for log entries via
+  `date -u +%Y-%m-%dT%H:%M:%SZ`, wall-clock for daily log via
+  `date +%H:%M`. Do not reuse cached timestamps.
+- **Module A is the contract.** Do not edit `JOURNAL.md` with sed/awk
+  from the skill body; always go through `journal-ops.py` so the state
+  region / log section invariants hold.

--- a/.claude/skills/daily-log-format.md
+++ b/.claude/skills/daily-log-format.md
@@ -58,6 +58,7 @@ Use these prefixes in brackets:
 | `architecture` | /architecture |
 | `idea` | /idea |
 | `setup` | /eddy-setup |
+| `checkpoint` | /checkpoint |
 
 ## Creating the Daily Log
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ A second memory that combines an Obsidian knowledge vault with workflow skills f
 
 | Command | Description |
 |---------|-------------|
-| `/new-task` | Start a task against a work stream — scaffolds a coding folder (clones repos + CLAUDE.md/AGENTS.md) by default; non-coding captures the output type |
+| `/new-task` | Start a task against a work stream — scaffolds a coding folder (clones repos + CLAUDE.md/AGENTS.md + JOURNAL.md) by default; non-coding captures the output type |
+| `/checkpoint` | Rewrite the task folder's `JOURNAL.md` state header and append a log entry after significant decisions, pivots, or blockers; `--promote` also notes it in the work stream |
 | `/ingest` | Categorize pasted Slack/email/info into vault notes |
 | `/my-prs` | Manage your authored PRs with review feedback todos |
 | `/review-prs` | List PRs awaiting your review action |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Cod
 - **`/whats-next`** — Prioritized next actions across all sources
 
 ### Capture
-- **`/new-task`** — Start a task against a work stream — scaffolds a coding folder (clones repos + CLAUDE.md/AGENTS.md) by default; non-coding captures the output type
+- **`/new-task`** — Start a task against a work stream — scaffolds a coding folder (clones repos + CLAUDE.md/AGENTS.md + JOURNAL.md) by default; non-coding captures the output type
 - **`/ingest`** — Drop Slack/email/meeting notes into the vault
 - **`/idea`** — Quick idea capture with auto-metadata
 
@@ -43,6 +43,7 @@ Powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Cod
 - **`/linear`** — Query/create/update via linearis/MCP
 
 ### Reflect & Maintain
+- **`/checkpoint`** — Capture task state in `JOURNAL.md`; `--promote` also drops a note into the work stream
 - **`/recap`** — Daily or weekly summary
 - **`/architecture`** — Interview-driven ARCHITECTURE.md
 - **`/docs`** — Refresh CLAUDE.md + README.md

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,40 @@
+# Tests
+
+Shell-level tests for eddy's helper scripts under `.claude/hooks/`.
+
+## Setup
+
+Install [bats-core](https://github.com/bats-core/bats-core) 1.x:
+
+```sh
+brew install bats-core           # macOS
+npm install -g bats              # cross-platform alternative
+```
+
+Python 3 (stdlib only) is required for the scripts under test. No other
+dependencies.
+
+## Run
+
+From the repo root:
+
+```sh
+bats tests/                      # all test files
+bats tests/journal-ops.bats      # one file
+```
+
+Add `--print-output-on-failure` to see stdout/stderr from failing cases.
+
+## Layout
+
+| Path                          | What it covers                                |
+|-------------------------------|-----------------------------------------------|
+| `tests/journal-ops.bats`      | Module A — state rewrite + log append         |
+| `tests/fixtures/`             | Sample `JOURNAL.md` files used by the tests   |
+
+## Writing tests
+
+`bats` does NOT bail on `[[ ... ]]` conditional failures — use `grep -q`,
+`diff`, or `[ ... ]` for assertions that must fail the test. The
+`contains` / `not_contains` helpers in `journal-ops.bats` are safe
+patterns to copy.

--- a/tests/fixtures/journal-empty-log.md
+++ b/tests/fixtures/journal-empty-log.md
@@ -1,0 +1,21 @@
+---
+type: task-journal
+task: fresh-task
+workstream: demo
+created: 2026-04-22
+---
+
+# Journal: fresh-task
+
+## Current State
+Just scaffolded.
+
+## Next Steps
+- Figure out what to build first.
+
+## Open Questions
+
+## Blockers
+
+## Log
+<!-- Append-only. Newest entries at the bottom. -->

--- a/tests/fixtures/journal-frontmatter-only.md
+++ b/tests/fixtures/journal-frontmatter-only.md
@@ -1,0 +1,6 @@
+---
+type: task-journal
+task: bare
+workstream: demo
+created: 2026-04-22
+---

--- a/tests/fixtures/journal-no-log-section.md
+++ b/tests/fixtures/journal-no-log-section.md
@@ -1,0 +1,20 @@
+---
+type: task-journal
+task: missing-log
+workstream: demo
+created: 2026-04-22
+---
+
+# Journal: missing-log
+
+## Current State
+Something useful.
+
+## Next Steps
+- Next thing.
+
+## Open Questions
+- ?
+
+## Blockers
+None.

--- a/tests/fixtures/journal-populated.md
+++ b/tests/fixtures/journal-populated.md
@@ -1,0 +1,33 @@
+---
+type: task-journal
+task: fix-auth-timeout
+workstream: platform-auth
+created: 2026-04-20
+---
+
+# Journal: fix-auth-timeout
+
+Intro prose is preserved.
+
+## Current State
+Investigating the token-refresh race condition.
+
+## Next Steps
+- Reproduce with the repro script from the linked ticket.
+
+## Open Questions
+- Does the race exist on the staging cluster too?
+
+## Blockers
+None right now.
+
+## Log
+<!-- Append-only. Newest entries at the bottom. -->
+
+### [session] 2026-04-20T09:15:00Z — initial exploration
+
+Started poking at the auth handler.
+
+### [checkpoint] 2026-04-20T14:00:00Z — narrowed to token-refresh
+
+Confirmed the race is in refresh, not issuance.

--- a/tests/journal-ops.bats
+++ b/tests/journal-ops.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+
+# Tests for Module A: journal file operations.
+# Exercises .claude/hooks/journal-ops.py via its CLI.
+#
+# Note: bats does NOT bail on `[[ ... ]]` returning false. Use `grep -q`
+# or `[ ... ]` for assertions that must fail the test.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  OPS="${REPO_ROOT}/.claude/hooks/journal-ops.py"
+  FIXTURES="${REPO_ROOT}/tests/fixtures"
+  WORK="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+contains() {
+  # contains <file> <substring>
+  grep -qF -- "$2" "$1"
+}
+
+not_contains() {
+  ! grep -qF -- "$2" "$1"
+}
+
+@test "read-state on populated journal returns the four state sections" {
+  run "$OPS" read-state "${FIXTURES}/journal-populated.md"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "## Current State"
+  echo "$output" | grep -qF "Investigating the token-refresh race condition."
+  echo "$output" | grep -qF "## Next Steps"
+  echo "$output" | grep -qF "## Open Questions"
+  echo "$output" | grep -qF "## Blockers"
+  # Must not leak the ## Log section or its entries.
+  ! echo "$output" | grep -qF "## Log"
+  ! echo "$output" | grep -qF "initial exploration"
+}
+
+@test "read-state on frontmatter-only journal returns empty output" {
+  run "$OPS" read-state "${FIXTURES}/journal-frontmatter-only.md"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "write-state rewrites state sections in place, preserving frontmatter and log" {
+  cp "${FIXTURES}/journal-populated.md" "${WORK}/j.md"
+  printf '## Current State\nRewritten — now in green-path.\n\n## Next Steps\n- Ship it.\n\n## Open Questions\n\n## Blockers\n' \
+    | "$OPS" write-state "${WORK}/j.md"
+
+  # Frontmatter preserved.
+  contains "${WORK}/j.md" "type: task-journal"
+  contains "${WORK}/j.md" "task: fix-auth-timeout"
+  contains "${WORK}/j.md" "created: 2026-04-20"
+  # Intro prose preserved.
+  contains "${WORK}/j.md" "# Journal: fix-auth-timeout"
+  contains "${WORK}/j.md" "Intro prose is preserved."
+  # Old state content replaced.
+  not_contains "${WORK}/j.md" "token-refresh race condition"
+  # New state content landed.
+  contains "${WORK}/j.md" "Rewritten — now in green-path."
+  contains "${WORK}/j.md" "- Ship it."
+  # Log section preserved verbatim (including its entries).
+  contains "${WORK}/j.md" "## Log"
+  contains "${WORK}/j.md" "initial exploration"
+  contains "${WORK}/j.md" "narrowed to token-refresh"
+}
+
+@test "write-state on frontmatter-only journal inserts state and log sections" {
+  cp "${FIXTURES}/journal-frontmatter-only.md" "${WORK}/j.md"
+  printf '## Current State\nHello.\n\n## Next Steps\n\n## Open Questions\n\n## Blockers\n' \
+    | "$OPS" write-state "${WORK}/j.md"
+
+  contains "${WORK}/j.md" "type: task-journal"
+  contains "${WORK}/j.md" "## Current State"
+  contains "${WORK}/j.md" "Hello."
+  contains "${WORK}/j.md" "## Log"
+}
+
+@test "write-state is idempotent — same input produces same output" {
+  cp "${FIXTURES}/journal-populated.md" "${WORK}/j.md"
+  printf '## Current State\nIdempotent.\n\n## Next Steps\n\n## Open Questions\n\n## Blockers\n' \
+    | "$OPS" write-state "${WORK}/j.md"
+  cp "${WORK}/j.md" "${WORK}/after-first.md"
+  printf '## Current State\nIdempotent.\n\n## Next Steps\n\n## Open Questions\n\n## Blockers\n' \
+    | "$OPS" write-state "${WORK}/j.md"
+  diff "${WORK}/after-first.md" "${WORK}/j.md"
+}
+
+@test "append-log appends a new entry to existing Log section" {
+  cp "${FIXTURES}/journal-populated.md" "${WORK}/j.md"
+  printf '### [checkpoint] 2026-04-22T11:00:00Z — new entry\n\nThis is the body.\n' \
+    | "$OPS" append-log "${WORK}/j.md"
+
+  # Prior entries preserved.
+  contains "${WORK}/j.md" "initial exploration"
+  contains "${WORK}/j.md" "narrowed to token-refresh"
+  # New entry appended.
+  contains "${WORK}/j.md" "new entry"
+  contains "${WORK}/j.md" "This is the body."
+  # Newest entry is at the bottom.
+  tail -c 300 "${WORK}/j.md" | grep -qF "This is the body."
+}
+
+@test "append-log on empty Log section appends without doubling the header" {
+  cp "${FIXTURES}/journal-empty-log.md" "${WORK}/j.md"
+  printf '### [checkpoint] 2026-04-22T11:00:00Z — first\n\nBody.\n' \
+    | "$OPS" append-log "${WORK}/j.md"
+
+  # Exactly one ## Log heading.
+  log_count=$(grep -c '^## Log' "${WORK}/j.md")
+  [ "$log_count" -eq 1 ]
+  contains "${WORK}/j.md" "[checkpoint] 2026-04-22T11:00:00Z — first"
+}
+
+@test "append-log creates Log section if missing" {
+  cp "${FIXTURES}/journal-no-log-section.md" "${WORK}/j.md"
+  printf '### [session] 2026-04-22T11:00:00Z — first session\n\nCaptured.\n' \
+    | "$OPS" append-log "${WORK}/j.md"
+
+  log_count=$(grep -c '^## Log' "${WORK}/j.md")
+  [ "$log_count" -eq 1 ]
+  contains "${WORK}/j.md" "first session"
+  contains "${WORK}/j.md" "Captured."
+}
+
+@test "append-log does not touch frontmatter or other sections" {
+  cp "${FIXTURES}/journal-populated.md" "${WORK}/j.md"
+  before_head="$(head -n 6 "${WORK}/j.md")"
+  printf '### [session] 2026-04-22T12:00:00Z — later\n\nMore.\n' \
+    | "$OPS" append-log "${WORK}/j.md"
+  after_head="$(head -n 6 "${WORK}/j.md")"
+  [ "$before_head" = "$after_head" ]
+
+  contains "${WORK}/j.md" "token-refresh race condition"
+  contains "${WORK}/j.md" "Reproduce with the repro script"
+}
+
+@test "append-log on frontmatter-only file creates Log section and writes entry" {
+  cp "${FIXTURES}/journal-frontmatter-only.md" "${WORK}/j.md"
+  printf '### [session] 2026-04-22T12:00:00Z — first\n\nEntry.\n' \
+    | "$OPS" append-log "${WORK}/j.md"
+
+  contains "${WORK}/j.md" "type: task-journal"
+  contains "${WORK}/j.md" "## Log"
+  contains "${WORK}/j.md" "Entry."
+}


### PR DESCRIPTION
Closes #30 (part of PRD #28). Stacked on top of #36 (slice 1).

## Summary
- **Module A** (`.claude/hooks/journal-ops.py`): Python 3 stdlib only. Three subcommands — `read-state`, `write-state`, `append-log` — with the state-region-rewrite / log-append-only contract.
- **bats harness** in `tests/` (first in the repo). 10 cases for Module A covering rewrite-in-place, missing state, empty/absent `## Log`, frontmatter-only file, and idempotency. `tests/README.md` covers setup.
- **`/checkpoint` skill**: rewrites state header, appends `[checkpoint]` log entry, optional `--promote` to draft a dated line into the work stream's `## Notes` section (draft → approve → write). Init path for journal-less folders (hooks deferred to slice 3).
- **Docs**: `/checkpoint` in README + top-level CLAUDE.md skill table; `checkpoint` added as a daily-log action type.

## Stack
Base = `slice-1-scaffold-journal` (#36). Slices 3, 5, 6 branch from here once merged to main.

## Test plan
- [ ] `brew install bats-core && bats tests/` — 10/10 green
- [ ] Run `/checkpoint` in a populated task folder → state header rewrites in place, `[checkpoint]` entry appended
- [ ] Run `/checkpoint --promote` → user-visible draft shown; approval appends one dated line to workstream's `## Notes`; rejection leaves workstream untouched
- [ ] Run `/checkpoint` in a folder without `JOURNAL.md` → init prompt, journal created from template on accept
- [ ] Confirm `notes/todos/running.md` is never written by `/checkpoint`
- [ ] Confirm daily log gets a `[checkpoint]` entry