### PR TITLE
Slice 3: SessionEnd hook + Module B (git delta collector)

### DIFF
--- a/.claude/hooks/git-delta.py
+++ b/.claude/hooks/git-delta.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Module B — git delta collector.
+
+Walks the immediate child directories of a task folder, detects git
+repositories, and emits a structured delta per repo: commits since the
+last run, files changed, current branch. Baseline state lives under
+`<task-folder>/.claude/journal-state/<repo>.last-ref`.
+
+Subcommands:
+
+  git-delta.py collect <task-folder>      # emits JSON to stdout
+  git-delta.py render                     # JSON on stdin → markdown entry
+
+Edge cases handled (per PRD #28):
+  - No commits since last run  → empty commits + files arrays.
+  - Newly cloned repo          → new_repo=True, no commits reported,
+                                 baseline written so next run sees delta.
+  - Detached HEAD              → branch reported as '(detached)'.
+  - Repo with no upstream      → unaffected (local refs only).
+  - Repo added mid-task        → same as newly cloned repo.
+  - Non-git child directories  → skipped silently.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+STATE_DIR_NAME = ".claude/journal-state"
+
+
+def run_git(repo: Path, *args: str) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def current_branch(repo: Path) -> str:
+    code, out, _ = run_git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    if code != 0:
+        return "(unknown)"
+    name = out.strip()
+    if name == "HEAD":
+        return "(detached)"
+    return name
+
+
+def current_head(repo: Path) -> str | None:
+    code, out, _ = run_git(repo, "rev-parse", "HEAD")
+    if code != 0:
+        return None
+    return out.strip() or None
+
+
+def commits_between(repo: Path, since: str, until: str) -> list[dict]:
+    # Format: <sha>\x1f<subject>, one per line. Avoids issues with tabs in subjects.
+    code, out, _ = run_git(
+        repo,
+        "log",
+        "--format=%H%x1f%s",
+        f"{since}..{until}",
+    )
+    if code != 0 or not out.strip():
+        return []
+    rows = []
+    for line in out.strip().splitlines():
+        if "\x1f" in line:
+            sha, subject = line.split("\x1f", 1)
+            rows.append({"sha": sha, "subject": subject})
+    return rows
+
+
+def files_between(repo: Path, since: str, until: str) -> list[str]:
+    code, out, _ = run_git(repo, "diff", "--name-only", f"{since}..{until}")
+    if code != 0:
+        return []
+    return [line for line in out.splitlines() if line]
+
+
+def collect(task_folder: Path) -> dict:
+    state_dir = task_folder / STATE_DIR_NAME
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    repos: list[dict] = []
+    for child in sorted(task_folder.iterdir()):
+        if not child.is_dir():
+            continue
+        if not (child / ".git").exists():
+            continue
+
+        name = child.name
+        branch = current_branch(child)
+        head = current_head(child)
+        state_file = state_dir / f"{name}.last-ref"
+
+        if head is None:
+            # Empty repo (no commits yet).
+            repos.append(
+                {
+                    "name": name,
+                    "branch": branch,
+                    "head": None,
+                    "new_repo": not state_file.exists(),
+                    "commits_since_last": [],
+                    "files_changed": [],
+                    "file_change_count": 0,
+                }
+            )
+            continue
+
+        if not state_file.exists():
+            # First time we've seen this repo under this task folder.
+            state_file.write_text(head + "\n")
+            repos.append(
+                {
+                    "name": name,
+                    "branch": branch,
+                    "head": head,
+                    "new_repo": True,
+                    "commits_since_last": [],
+                    "files_changed": [],
+                    "file_change_count": 0,
+                }
+            )
+            continue
+
+        last_ref = state_file.read_text().strip()
+        commits = commits_between(child, last_ref, head) if last_ref else []
+        files = files_between(child, last_ref, head) if last_ref else []
+
+        # Update baseline for next run.
+        state_file.write_text(head + "\n")
+
+        repos.append(
+            {
+                "name": name,
+                "branch": branch,
+                "head": head,
+                "new_repo": False,
+                "commits_since_last": commits,
+                "files_changed": files,
+                "file_change_count": len(files),
+            }
+        )
+
+    return {
+        "task_folder": str(task_folder),
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "repos": repos,
+    }
+
+
+def render(data: dict) -> str:
+    ts = data.get("generated_at", datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    repos = data.get("repos", [])
+
+    # One-line reason: summarize across repos.
+    total_commits = sum(len(r.get("commits_since_last", [])) for r in repos)
+    total_files = sum(r.get("file_change_count", 0) for r in repos)
+    if total_commits == 0 and total_files == 0:
+        reason = "session ended — no new commits"
+    else:
+        reason = f"session ended — {total_commits} commit(s), {total_files} file(s) changed"
+
+    lines = [f"### [session] {ts} — {reason}", ""]
+    if not repos:
+        lines.append("_No child repositories detected._")
+        return "\n".join(lines) + "\n"
+
+    for r in repos:
+        name = r.get("name", "?")
+        branch = r.get("branch", "?")
+        head = r.get("head") or "(no commits)"
+        head_short = head[:8] if len(head) >= 8 else head
+        flag = " _(new repo baselined)_" if r.get("new_repo") else ""
+        lines.append(f"**{name}** — branch `{branch}` @ `{head_short}`{flag}")
+        commits = r.get("commits_since_last", [])
+        if commits:
+            lines.append("")
+            lines.append("Commits:")
+            for c in commits:
+                short = c["sha"][:8]
+                lines.append(f"- `{short}` {c['subject']}")
+        files = r.get("files_changed", [])
+        if files:
+            lines.append("")
+            lines.append(f"Files changed ({len(files)}):")
+            for f in files:
+                lines.append(f"- `{f}`")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: git-delta.py {collect|render} [<task-folder>]", file=sys.stderr)
+        return 2
+
+    cmd = argv[1]
+
+    if cmd == "collect":
+        if len(argv) < 3:
+            print("usage: git-delta.py collect <task-folder>", file=sys.stderr)
+            return 2
+        task_folder = Path(argv[2]).resolve()
+        if not task_folder.is_dir():
+            print(f"git-delta: not a directory: {task_folder}", file=sys.stderr)
+            return 1
+        data = collect(task_folder)
+        json.dump(data, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    if cmd == "render":
+        try:
+            data = json.load(sys.stdin)
+        except json.JSONDecodeError as exc:
+            print(f"git-delta: invalid JSON on stdin: {exc}", file=sys.stderr)
+            return 1
+        sys.stdout.write(render(data))
+        return 0
+
+    print(f"git-delta: unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Claude Code SessionEnd hook for eddy task folders.
+#
+# On session end, if the CWD has a JOURNAL.md:
+#   1. Collect a git delta across child repos (Module B).
+#   2. Render it to markdown.
+#   3. Append a [session] log entry via journal-ops (Module A).
+#
+# The hook payload on stdin is currently unused. Slice 4 of PRD #28 will
+# read the transcript path from it to add an LLM summary.
+
+set -e
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASK_FOLDER="$PWD"
+JOURNAL="${TASK_FOLDER}/JOURNAL.md"
+
+# No journal here → nothing to do. Exit cleanly so the hook is safe to
+# scaffold into any folder (though /new-task only scaffolds it into
+# folders that already have JOURNAL.md).
+if [ ! -f "$JOURNAL" ]; then
+  exit 0
+fi
+
+# Drain any stdin payload — Claude Code writes JSON here. We don't need
+# it yet, but we must not leave it unread if the hook runner is strict.
+if [ ! -t 0 ]; then
+  cat > /dev/null
+fi
+
+DELTA_JSON="$("${HOOK_DIR}/git-delta.py" collect "$TASK_FOLDER")"
+ENTRY="$(printf '%s' "$DELTA_JSON" | "${HOOK_DIR}/git-delta.py" render)"
+printf '%s' "$ENTRY" | "${HOOK_DIR}/journal-ops.py" append-log "$JOURNAL"

--- a/.claude/skills/checkpoint/SKILL.md
+++ b/.claude/skills/checkpoint/SKILL.md
@@ -134,12 +134,37 @@ On yes:
    `## Work Stream` line and the folder name), otherwise ask the user.
 2. Copy the template to `./JOURNAL.md`, substituting `{{task}}`,
    `{{workstream}}`, and `{{created}}` (today's date).
-3. Proceed with steps 2–3 as normal.
+3. Install the `SessionEnd` hook into `./.claude/settings.json` so
+   auto-capture works going forward. Write (merging with any existing
+   file):
+
+   ```json
+   {
+     "hooks": {
+       "SessionEnd": [
+         {
+           "hooks": [
+             {
+               "type": "command",
+               "command": "<absolute-workflow-repo>/.claude/hooks/session-end.sh"
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+   `<absolute-workflow-repo>` is the absolute path to the workflow repo
+   (parse it from the task folder's `CLAUDE.md` Workflow Repo line if
+   present, else ask the user). If a SessionEnd hook already exists
+   pointing elsewhere, ask before replacing.
+4. Proceed with steps 2–3 as normal.
 
 On no: stop silently.
 
-Hook installation (`SessionStart`/`SessionEnd`) is handled in a later
-slice of PRD #28 and will extend this init path.
+Slice 5 of PRD #28 will add a `SessionStart` hook alongside this
+install step.
 
 ### 6. Append a daily log entry
 

--- a/.claude/skills/new-task/SKILL.md
+++ b/.claude/skills/new-task/SKILL.md
@@ -90,6 +90,27 @@ Then match the task to a work stream:
 
 7. Create `<dev-dir>/<task-name>/JOURNAL.md` from `notes/templates/journal.md`, substituting `{{task}}` with the kebab-case task name, `{{workstream}}` with the matched work stream name, and `{{created}}` with today's date (`YYYY-MM-DD`). The rest of the template (state header, empty `## Log`) is written through unchanged. The journal stays local to the task folder — it is not copied into the vault. If `JOURNAL.md` already exists in the folder, leave it alone rather than overwriting.
 
+8. Install the SessionEnd hook into the task folder's `.claude/settings.json` so each Claude Code session auto-appends a `[session]` log entry to `JOURNAL.md` on exit. Write (merging with any existing file):
+
+   ```json
+   {
+     "hooks": {
+       "SessionEnd": [
+         {
+           "hooks": [
+             {
+               "type": "command",
+               "command": "<absolute-workflow-repo>/.claude/hooks/session-end.sh"
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+   Substitute `<absolute-workflow-repo>` with the same absolute path used in the task `CLAUDE.md`'s Workflow Repo section. If `.claude/settings.json` already exists in the folder, merge the `hooks.SessionEnd` entry in rather than overwriting the file. If it already has a SessionEnd hook pointing elsewhere, ask the user before replacing.
+
 #### 4b. Non-Coding Mode
 
 The user has indicated this isn't a coding task. No filesystem scaffolding — just capture what kind of output is expected and an identifier for the task.
@@ -132,7 +153,7 @@ Create the `## Tasks` section just above `## Notes` if it's missing. No `ended:`
 
 Tell the user:
 
-- **Coding mode:** task folder location, what was cloned, the `CLAUDE.md` + `AGENTS.md` symlink, the scaffolded `JOURNAL.md`, the work stream `## Tasks` bullet appended (quote the line), the daily log entry, and how to resume (`cd <folder>` and launch Claude Code or Codex).
+- **Coding mode:** task folder location, what was cloned, the `CLAUDE.md` + `AGENTS.md` symlink, the scaffolded `JOURNAL.md`, the `.claude/settings.json` with the `SessionEnd` hook wired up, the work stream `## Tasks` bullet appended (quote the line), the daily log entry, and how to resume (`cd <folder>` and launch Claude Code or Codex).
 - **Non-coding mode:** the captured task name, work stream, and output type; the work stream `## Tasks` bullet (quote the line); the daily log entry; and a reminder that the output file wasn't pre-created — the user is expected to produce it themselves.
 
 ## Important Rules

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,10 +27,12 @@ Add `--print-output-on-failure` to see stdout/stderr from failing cases.
 
 ## Layout
 
-| Path                          | What it covers                                |
-|-------------------------------|-----------------------------------------------|
-| `tests/journal-ops.bats`      | Module A — state rewrite + log append         |
-| `tests/fixtures/`             | Sample `JOURNAL.md` files used by the tests   |
+| Path                          | What it covers                                         |
+|-------------------------------|--------------------------------------------------------|
+| `tests/journal-ops.bats`      | Module A — state rewrite + log append                  |
+| `tests/git-delta.bats`        | Module B — git delta collect + render                  |
+| `tests/session-end.bats`      | Integration — SessionEnd hook end-to-end               |
+| `tests/fixtures/`             | Sample `JOURNAL.md` files used by the tests            |
 
 ## Writing tests
 

--- a/tests/git-delta.bats
+++ b/tests/git-delta.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+
+# Tests for Module B: git delta collector.
+# Exercises .claude/hooks/git-delta.py collect via its CLI.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  DELTA="${REPO_ROOT}/.claude/hooks/git-delta.py"
+  TASK="$(mktemp -d)"
+
+  # Git config so commits don't warn in CI-like environments.
+  export GIT_AUTHOR_NAME="Test"
+  export GIT_AUTHOR_EMAIL="test@example.com"
+  export GIT_COMMITTER_NAME="Test"
+  export GIT_COMMITTER_EMAIL="test@example.com"
+}
+
+teardown() {
+  rm -rf "$TASK"
+}
+
+mkrepo() {
+  # mkrepo <name> — init a git repo with one initial commit
+  local name="$1"
+  local dir="${TASK}/${name}"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+  echo "initial" > "${dir}/README.md"
+  git -C "$dir" add README.md
+  git -C "$dir" commit -q -m "initial commit"
+}
+
+@test "collect on task folder with no repos emits empty repos array" {
+  run "$DELTA" collect "$TASK"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['repos']==[], d"
+}
+
+@test "collect on new repo (no prior state) baselines and reports no commits" {
+  mkrepo foo
+  run "$DELTA" collect "$TASK"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+repos = {r['name']: r for r in d['repos']}
+r = repos['foo']
+assert r['new_repo'] is True, r
+assert r['commits_since_last'] == [], r
+assert r['files_changed'] == [], r
+assert r['branch'] == 'main', r
+"
+  # A state file should now exist so the next run has a baseline.
+  [ -f "${TASK}/.claude/journal-state/foo.last-ref" ]
+}
+
+@test "collect after new commit reports the commit + files changed" {
+  mkrepo foo
+  # Baseline.
+  "$DELTA" collect "$TASK" > /dev/null
+
+  echo "change" >> "${TASK}/foo/README.md"
+  echo "new" > "${TASK}/foo/NOTES.md"
+  git -C "${TASK}/foo" add -A
+  git -C "${TASK}/foo" commit -q -m "add notes, update readme"
+
+  run "$DELTA" collect "$TASK"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+r = {x['name']: x for x in d['repos']}['foo']
+assert r['new_repo'] is False, r
+assert len(r['commits_since_last']) == 1, r
+assert r['commits_since_last'][0]['subject'] == 'add notes, update readme', r
+assert set(r['files_changed']) == {'README.md', 'NOTES.md'}, r
+assert r['file_change_count'] == 2, r
+"
+}
+
+@test "collect with no commits since last run reports zero delta" {
+  mkrepo foo
+  "$DELTA" collect "$TASK" > /dev/null
+  run "$DELTA" collect "$TASK"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+r = {x['name']: x for x in d['repos']}['foo']
+assert r['new_repo'] is False, r
+assert r['commits_since_last'] == [], r
+assert r['files_changed'] == [], r
+"
+}
+
+@test "collect handles detached HEAD" {
+  mkrepo foo
+  # Add a second commit, then detach to the first.
+  echo "two" >> "${TASK}/foo/README.md"
+  git -C "${TASK}/foo" commit -q -am "second"
+  FIRST_SHA=$(git -C "${TASK}/foo" rev-list --max-parents=0 HEAD)
+  git -C "${TASK}/foo" checkout -q "$FIRST_SHA"
+
+  run "$DELTA" collect "$TASK"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+r = {x['name']: x for x in d['repos']}['foo']
+assert r['branch'] in ('HEAD', '(detached)'), r
+"
+}
+
+@test "collect handles repo added mid-task (new repo in second run)" {
+  mkrepo foo
+  "$DELTA" collect "$TASK" > /dev/null
+
+  # Second run after adding a new repo.
+  mkrepo bar
+  run "$DELTA" collect "$TASK"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+repos = {r['name']: r for r in d['repos']}
+assert repos['foo']['new_repo'] is False, repos
+assert repos['bar']['new_repo'] is True, repos
+"
+}
+
+@test "collect skips non-git directories" {
+  mkrepo foo
+  mkdir -p "${TASK}/notes"
+  echo "text" > "${TASK}/notes/stuff.md"
+
+  run "$DELTA" collect "$TASK"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+names = sorted(r['name'] for r in d['repos'])
+assert names == ['foo'], names
+"
+}
+
+@test "render takes delta JSON on stdin and produces a markdown entry" {
+  mkrepo foo
+  "$DELTA" collect "$TASK" > /dev/null
+  echo "x" >> "${TASK}/foo/README.md"
+  git -C "${TASK}/foo" commit -q -am "tweak readme"
+
+  json="$("$DELTA" collect "$TASK")"
+  run bash -c "echo '$json' | '$DELTA' render"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "[session]"
+  echo "$output" | grep -qF "foo"
+  echo "$output" | grep -qF "tweak readme"
+  echo "$output" | grep -qF "README.md"
+}
+
+@test "render on empty repos list still produces a valid entry" {
+  json='{"task_folder": "'"$TASK"'", "generated_at": "2026-04-22T00:00:00Z", "repos": []}'
+  run bash -c "echo '$json' | '$DELTA' render"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "[session]"
+}

--- a/tests/session-end.bats
+++ b/tests/session-end.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+# Integration smoke for .claude/hooks/session-end.sh.
+# Runs the hook in a temp task folder with a JOURNAL.md and a child
+# repo, asserts a [session] entry lands in the journal.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  HOOK="${REPO_ROOT}/.claude/hooks/session-end.sh"
+  TEMPLATE="${REPO_ROOT}/notes/templates/journal.md"
+  TASK="$(mktemp -d)"
+
+  export GIT_AUTHOR_NAME="Test"
+  export GIT_AUTHOR_EMAIL="test@example.com"
+  export GIT_COMMITTER_NAME="Test"
+  export GIT_COMMITTER_EMAIL="test@example.com"
+
+  cp "$TEMPLATE" "${TASK}/JOURNAL.md"
+}
+
+teardown() {
+  rm -rf "$TASK"
+}
+
+@test "session-end no-ops when JOURNAL.md is absent" {
+  bare="$(mktemp -d)"
+  (cd "$bare" && "$HOOK" < /dev/null)
+  rmdir "$bare"
+}
+
+@test "session-end appends a [session] entry with git delta" {
+  mkdir -p "${TASK}/foo"
+  git -C "${TASK}/foo" init -q -b main
+  echo "hello" > "${TASK}/foo/README.md"
+  git -C "${TASK}/foo" add README.md
+  git -C "${TASK}/foo" commit -q -m "initial"
+
+  # First run: baselines the repo (new_repo=true, no commits reported).
+  (cd "$TASK" && "$HOOK" < /dev/null)
+
+  # Make a commit, run again — this time we should see the commit.
+  echo "change" >> "${TASK}/foo/README.md"
+  git -C "${TASK}/foo" commit -q -am "add change line"
+
+  (cd "$TASK" && "$HOOK" < /dev/null)
+
+  grep -qF "[session]" "${TASK}/JOURNAL.md"
+  grep -qF "add change line" "${TASK}/JOURNAL.md"
+  grep -qF "foo" "${TASK}/JOURNAL.md"
+}
+
+@test "session-end tolerates JSON on stdin without crashing" {
+  mkdir -p "${TASK}/foo"
+  git -C "${TASK}/foo" init -q -b main
+  echo "hello" > "${TASK}/foo/README.md"
+  git -C "${TASK}/foo" add README.md
+  git -C "${TASK}/foo" commit -q -m "initial"
+
+  payload='{"session_id":"abc","transcript_path":"/tmp/t.jsonl"}'
+  (cd "$TASK" && printf '%s' "$payload" | "$HOOK")
+
+  grep -qF "[session]" "${TASK}/JOURNAL.md"
+}


### PR DESCRIPTION
Closes #31 (part of PRD #28). Stacked on top of #37 (slice 2).

## Summary
- **Module B** (`.claude/hooks/git-delta.py`): `collect <task-folder>` emits JSON per child git repo — commits since last seen, files changed, branch, `new_repo` flag, current HEAD. `render` turns that JSON into a markdown `[session]` entry. Baseline state lives under `<task>/.claude/journal-state/<repo>.last-ref`.
- **SessionEnd hook** (`.claude/hooks/session-end.sh`): exits 0 silently when the CWD has no `JOURNAL.md`. Otherwise drains hook-payload stdin and pipes `git-delta collect → render → journal-ops append-log`.
- **`/new-task`**: coding mode writes `.claude/settings.json` into the task folder with the `SessionEnd` hook wired to the workflow-repo's absolute hook path.
- **`/checkpoint` init path**: now installs the `SessionEnd` hook too, so retroactive adoption is single-shot.
- **Tests**: 9 Module B cases (including detached HEAD, new-repo baselining, no-commits, repo-added-mid-task, non-git child). 3 integration cases for the hook on temp git repos. 22/22 across the harness.

## Stack
Base = `slice-2-checkpoint-module-a` (#37). Slice 4 (LLM summary) branches from here.

## Test plan
- [ ] `bats tests/` — 22/22 green
- [ ] Scaffold a fresh task folder with `/new-task` → confirm `.claude/settings.json` has `SessionEnd` entry pointing to `<workflow-repo>/.claude/hooks/session-end.sh`
- [ ] Start/end a Claude Code session in the folder, make a trivial commit → confirm a new `[session]` block with commit subject + files changed appears in `JOURNAL.md`
- [ ] Open a pre-feature folder (no `JOURNAL.md`) and run `/checkpoint` init → confirm both `JOURNAL.md` and the `SessionEnd` hook are installed