### PR TITLE
Slice 4: LLM session summary + opt-out knob

### DIFF
--- a/.claude/hooks/git-delta.py
+++ b/.claude/hooks/git-delta.py
@@ -157,7 +157,7 @@ def collect(task_folder: Path) -> dict:
     }
 
 
-def render(data: dict) -> str:
+def render(data: dict, summary: str = "") -> str:
     ts = data.get("generated_at", datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
     repos = data.get("repos", [])
 
@@ -170,6 +170,17 @@ def render(data: dict) -> str:
         reason = f"session ended — {total_commits} commit(s), {total_files} file(s) changed"
 
     lines = [f"### [session] {ts} — {reason}", ""]
+
+    summary = (summary or "").strip()
+    if summary:
+        lines.append("**Session summary**")
+        lines.append("")
+        lines.append(summary)
+        lines.append("")
+        if repos:
+            lines.append("**Repo changes**")
+            lines.append("")
+
     if not repos:
         lines.append("_No child repositories detected._")
         return "\n".join(lines) + "\n"
@@ -220,12 +231,25 @@ def main(argv: list[str]) -> int:
         return 0
 
     if cmd == "render":
+        summary = ""
+        # Parse optional --summary-file <path>.
+        rest = argv[2:]
+        i = 0
+        while i < len(rest):
+            if rest[i] == "--summary-file" and i + 1 < len(rest):
+                summary_path = Path(rest[i + 1])
+                if summary_path.is_file():
+                    summary = summary_path.read_text()
+                i += 2
+            else:
+                print(f"git-delta: unexpected arg: {rest[i]}", file=sys.stderr)
+                return 2
         try:
             data = json.load(sys.stdin)
         except json.JSONDecodeError as exc:
             print(f"git-delta: invalid JSON on stdin: {exc}", file=sys.stderr)
             return 1
-        sys.stdout.write(render(data))
+        sys.stdout.write(render(data, summary=summary))
         return 0
 
     print(f"git-delta: unknown subcommand: {cmd}", file=sys.stderr)

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -3,31 +3,73 @@
 #
 # On session end, if the CWD has a JOURNAL.md:
 #   1. Collect a git delta across child repos (Module B).
-#   2. Render it to markdown.
-#   3. Append a [session] log entry via journal-ops (Module A).
+#   2. Unless the `journal_session_summary` config knob is off, generate
+#      a 2–3 sentence LLM summary from the session transcript (Module C).
+#   3. Render a [session] markdown entry (Module B render).
+#   4. Append it to JOURNAL.md (Module A).
 #
-# The hook payload on stdin is currently unused. Slice 4 of PRD #28 will
-# read the transcript path from it to add an LLM summary.
+# Reads the hook payload (JSON) from stdin to extract `transcript_path`
+# for the summary step. Everything but step 1 is best-effort; failures
+# fall back to a git-delta-only entry.
 
-set -e
+set -u
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_REPO="$(cd "${HOOK_DIR}/../.." && pwd)"
 TASK_FOLDER="$PWD"
 JOURNAL="${TASK_FOLDER}/JOURNAL.md"
+CONFIG="${WORKFLOW_REPO}/config.md"
 
-# No journal here → nothing to do. Exit cleanly so the hook is safe to
-# scaffold into any folder (though /new-task only scaffolds it into
-# folders that already have JOURNAL.md).
 if [ ! -f "$JOURNAL" ]; then
   exit 0
 fi
 
-# Drain any stdin payload — Claude Code writes JSON here. We don't need
-# it yet, but we must not leave it unread if the hook runner is strict.
+# Read hook payload JSON (may be empty if invoked manually).
+PAYLOAD=""
 if [ ! -t 0 ]; then
-  cat > /dev/null
+  PAYLOAD="$(cat)"
+fi
+
+# Resolve the journal_session_summary config knob. Default: on.
+# Parses a line like "- **Session Summary:** on" under "## Task Journal".
+summary_enabled="on"
+if [ -f "$CONFIG" ]; then
+  line="$(grep -iE '^- \*\*Session Summary:\*\*' "$CONFIG" 2>/dev/null | head -1 || true)"
+  if [ -n "$line" ]; then
+    val="$(printf '%s' "$line" | sed -E 's/^- \*\*Session Summary:\*\*[[:space:]]*//; s/[[:space:]]*<!--.*-->.*$//; s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]')"
+    case "$val" in
+      off|false|no|0) summary_enabled="off" ;;
+    esac
+  fi
 fi
 
 DELTA_JSON="$("${HOOK_DIR}/git-delta.py" collect "$TASK_FOLDER")"
-ENTRY="$(printf '%s' "$DELTA_JSON" | "${HOOK_DIR}/git-delta.py" render)"
+
+SUMMARY_FILE=""
+if [ "$summary_enabled" = "on" ] && [ -n "$PAYLOAD" ]; then
+  TRANSCRIPT_PATH="$(
+    printf '%s' "$PAYLOAD" \
+      | python3 -c 'import json,sys
+try:
+  d=json.load(sys.stdin)
+  print(d.get("transcript_path",""))
+except Exception:
+  pass' 2>/dev/null
+  )"
+  if [ -n "$TRANSCRIPT_PATH" ] && [ -r "$TRANSCRIPT_PATH" ]; then
+    SUMMARY_FILE="$(mktemp)"
+    if ! "${HOOK_DIR}/summarize-transcript.sh" "$TRANSCRIPT_PATH" > "$SUMMARY_FILE" 2>/dev/null; then
+      rm -f "$SUMMARY_FILE"
+      SUMMARY_FILE=""
+    fi
+  fi
+fi
+
+if [ -n "$SUMMARY_FILE" ]; then
+  ENTRY="$(printf '%s' "$DELTA_JSON" | "${HOOK_DIR}/git-delta.py" render --summary-file "$SUMMARY_FILE")"
+  rm -f "$SUMMARY_FILE"
+else
+  ENTRY="$(printf '%s' "$DELTA_JSON" | "${HOOK_DIR}/git-delta.py" render)"
+fi
+
 printf '%s' "$ENTRY" | "${HOOK_DIR}/journal-ops.py" append-log "$JOURNAL"

--- a/.claude/hooks/summarize-transcript.sh
+++ b/.claude/hooks/summarize-transcript.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Module C — session transcript summarizer.
+#
+# Wraps `claude -p` to turn a Claude Code session transcript into a 2–3
+# sentence summary focused on decisions, attempts, and next steps. Used
+# by session-end.sh to fill the **Session summary** block of [session]
+# journal entries.
+#
+# Usage:
+#   summarize-transcript.sh <transcript-path>
+#
+# Exits 0 and prints the summary to stdout on success. Exits non-zero
+# with an empty stdout on any failure (missing file, missing claude CLI,
+# non-zero exit from claude -p, timeout). session-end.sh treats a
+# failure here as "no summary available" and still writes the git-delta
+# portion of the entry.
+
+TRANSCRIPT="${1:-}"
+
+if [ -z "$TRANSCRIPT" ] || [ ! -r "$TRANSCRIPT" ]; then
+  exit 1
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  exit 1
+fi
+
+PROMPT='Summarize this Claude Code session transcript in 2-3 sentences. Focus on: (1) what was attempted or decided, (2) any dead ends or pivots, (3) what is explicitly left for next session. Do not recap file names or commands. Write plainly; no preamble like "In this session".'
+
+# Pipe the transcript (JSONL) as stdin to `claude -p`. Guard against
+# unbounded latency with a timeout — if the summarizer takes more than
+# 60s the hook should still finish writing the delta portion.
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT=(gtimeout 60)
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT=(timeout 60)
+else
+  TIMEOUT=()
+fi
+
+"${TIMEOUT[@]}" claude -p "$PROMPT" < "$TRANSCRIPT"

--- a/.claude/skills/config-format.md
+++ b/.claude/skills/config-format.md
@@ -19,6 +19,9 @@ Read `config.md` and extract values from the markdown list items. Each setting i
 - **Dev Directory** — Base directory for task folders (default: `~/dev`)
 - **Default Branch** — Default branch name (default: `main`)
 
+### Task Journal
+- **Session Summary** — `on` (default) or `off`. When `on`, the `SessionEnd` hook asks `claude -p` for a 2–3 sentence summary of the session transcript and writes it into each `[session]` journal entry alongside the git delta. When `off`, only the git delta is written. Consumed by `.claude/hooks/session-end.sh`.
+
 ### Optional Integrations
 
 #### Jira

--- a/config.md
+++ b/config.md
@@ -7,6 +7,10 @@
 - **Dev Directory:** ~/dev
 - **Default Branch:** main
 
+## Task Journal
+<!-- Controls what the SessionEnd hook (.claude/hooks/session-end.sh) writes into each task folder's JOURNAL.md. -->
+- **Session Summary:** on <!-- on | off. Off → git-delta only; on → also run a 2-3 sentence LLM summary via `claude -p`. -->
+
 ## Optional Integrations
 
 ### Jira

--- a/tests/git-delta.bats
+++ b/tests/git-delta.bats
@@ -164,3 +164,38 @@ assert names == ['foo'], names
   [ "$status" -eq 0 ]
   echo "$output" | grep -qF "[session]"
 }
+
+@test "render --summary-file inserts summary section above repo changes" {
+  mkrepo foo
+  "$DELTA" collect "$TASK" > /dev/null
+  echo "x" >> "${TASK}/foo/README.md"
+  git -C "${TASK}/foo" commit -q -am "tweak readme"
+
+  json="$("$DELTA" collect "$TASK")"
+  summary_file="$(mktemp)"
+  printf 'Decided to retry with backoff. Left reproducing the staging case for next session.\n' > "$summary_file"
+
+  run bash -c "echo '$json' | '$DELTA' render --summary-file '$summary_file'"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "**Session summary**"
+  echo "$output" | grep -qF "Decided to retry with backoff."
+  echo "$output" | grep -qF "**Repo changes**"
+  echo "$output" | grep -qF "tweak readme"
+
+  # Summary section appears before the repo changes header.
+  summary_pos=$(echo "$output" | grep -n "Session summary" | head -1 | cut -d: -f1)
+  repo_pos=$(echo "$output" | grep -n "Repo changes" | head -1 | cut -d: -f1)
+  [ "$summary_pos" -lt "$repo_pos" ]
+
+  rm -f "$summary_file"
+}
+
+@test "render --summary-file with empty file behaves like no summary" {
+  json='{"task_folder": "'"$TASK"'", "generated_at": "2026-04-22T00:00:00Z", "repos": []}'
+  empty="$(mktemp)"
+  run bash -c "echo '$json' | '$DELTA' render --summary-file '$empty'"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "[session]"
+  ! echo "$output" | grep -qF "**Session summary**"
+  rm -f "$empty"
+}

--- a/tests/session-end.bats
+++ b/tests/session-end.bats
@@ -61,3 +61,105 @@ teardown() {
 
   grep -qF "[session]" "${TASK}/JOURNAL.md"
 }
+
+@test "session-end falls back to delta-only entry when summary is unavailable" {
+  # No `claude` CLI on PATH in the test environment → summarize-transcript.sh
+  # exits non-zero → hook should still produce a delta entry.
+  mkdir -p "${TASK}/foo"
+  git -C "${TASK}/foo" init -q -b main
+  echo "hi" > "${TASK}/foo/README.md"
+  git -C "${TASK}/foo" add README.md
+  git -C "${TASK}/foo" commit -q -m "bootstrap"
+
+  # Point at a real transcript so the hook tries the summary path.
+  transcript="$(mktemp)"
+  echo '{"role":"user","content":"hi"}' > "$transcript"
+
+  payload='{"session_id":"abc","transcript_path":"'"$transcript"'"}'
+  (cd "$TASK" && PATH=/usr/bin:/bin printf '%s' "$payload" | "$HOOK") || true
+
+  grep -qF "[session]" "${TASK}/JOURNAL.md"
+  grep -qF "foo" "${TASK}/JOURNAL.md"
+  # No **Session summary** section (claude not available).
+  ! grep -qF "**Session summary**" "${TASK}/JOURNAL.md"
+
+  rm -f "$transcript"
+}
+
+@test "session-end includes LLM summary when knob is on and claude is available" {
+  # Stub `claude` on PATH so the test doesn't need the real CLI.
+  BIN="$(mktemp -d)"
+  cat > "${BIN}/claude" <<'SH'
+#!/usr/bin/env bash
+cat > /dev/null
+echo "STUB_SUMMARY_LINE decided to stop after probing the race."
+SH
+  chmod +x "${BIN}/claude"
+
+  mkdir -p "${TASK}/foo"
+  git -C "${TASK}/foo" init -q -b main
+  echo "hi" > "${TASK}/foo/README.md"
+  git -C "${TASK}/foo" add README.md
+  git -C "${TASK}/foo" commit -q -m "bootstrap"
+
+  transcript="$(mktemp)"
+  echo '{"role":"user","content":"hi"}' > "$transcript"
+  payload='{"transcript_path":"'"$transcript"'"}'
+
+  (cd "$TASK" && export PATH="${BIN}:$PATH" && printf '%s' "$payload" | "$HOOK")
+
+  grep -qF "STUB_SUMMARY_LINE" "${TASK}/JOURNAL.md"
+  grep -qF "**Session summary**" "${TASK}/JOURNAL.md"
+
+  rm -rf "$BIN" "$transcript"
+}
+
+@test "session-end honors Session Summary: off in config.md" {
+  BIN="$(mktemp -d)"
+  cat > "${BIN}/claude" <<'SH'
+#!/usr/bin/env bash
+cat > /dev/null
+echo "STUB_SUMMARY_LINE should not appear"
+SH
+  chmod +x "${BIN}/claude"
+
+  # Point at a repo-shaped config with the knob off.
+  CFG_ROOT="$(mktemp -d)"
+  mkdir -p "${CFG_ROOT}/.claude"
+  cp "${REPO_ROOT}/.claude/hooks/journal-ops.py" "${CFG_ROOT}/.claude/"
+  cp "${REPO_ROOT}/.claude/hooks/git-delta.py" "${CFG_ROOT}/.claude/"
+  cp "${REPO_ROOT}/.claude/hooks/summarize-transcript.sh" "${CFG_ROOT}/.claude/"
+  cp "${REPO_ROOT}/.claude/hooks/session-end.sh" "${CFG_ROOT}/.claude/"
+  mkdir -p "${CFG_ROOT}/.claude/hooks"
+  mv "${CFG_ROOT}/.claude/journal-ops.py" "${CFG_ROOT}/.claude/hooks/"
+  mv "${CFG_ROOT}/.claude/git-delta.py" "${CFG_ROOT}/.claude/hooks/"
+  mv "${CFG_ROOT}/.claude/summarize-transcript.sh" "${CFG_ROOT}/.claude/hooks/"
+  mv "${CFG_ROOT}/.claude/session-end.sh" "${CFG_ROOT}/.claude/hooks/"
+  chmod +x "${CFG_ROOT}/.claude/hooks/"*
+  cat > "${CFG_ROOT}/config.md" <<'CFG'
+# Configuration
+
+## Task Journal
+- **Session Summary:** off
+CFG
+  TASK2="${CFG_ROOT}/task"
+  mkdir -p "$TASK2"
+  cp "${REPO_ROOT}/notes/templates/journal.md" "${TASK2}/JOURNAL.md"
+  mkdir -p "${TASK2}/foo"
+  git -C "${TASK2}/foo" init -q -b main
+  echo "hi" > "${TASK2}/foo/README.md"
+  git -C "${TASK2}/foo" add README.md
+  git -C "${TASK2}/foo" commit -q -m "bootstrap"
+
+  transcript="$(mktemp)"
+  echo '{"role":"user","content":"hi"}' > "$transcript"
+  payload='{"transcript_path":"'"$transcript"'"}'
+
+  (cd "$TASK2" && export PATH="${BIN}:$PATH" && printf '%s' "$payload" | "${CFG_ROOT}/.claude/hooks/session-end.sh")
+
+  grep -qF "[session]" "${TASK2}/JOURNAL.md"
+  ! grep -qF "STUB_SUMMARY_LINE" "${TASK2}/JOURNAL.md"
+  ! grep -qF "**Session summary**" "${TASK2}/JOURNAL.md"
+
+  rm -rf "$BIN" "$CFG_ROOT" "$transcript"
+}


### PR DESCRIPTION
Closes #32 (part of PRD #28). Stacked on top of #38 (slice 3).

## Summary
- **Module C** (`.claude/hooks/summarize-transcript.sh`): wraps `claude -p`; pipes the session transcript in, emits 2–3 sentences. Best-effort — failures exit non-zero so the hook falls back to a delta-only entry.
- **`git-delta.py render --summary-file`**: when provided, renders a `**Session summary**` block above `**Repo changes**`. Empty/absent file behaves like no summary.
- **`session-end.sh`**: parses hook-payload JSON for `transcript_path`, reads new `config.md` → `## Task Journal` → `Session Summary` knob (default `on`), invokes Module C unless the knob is off, passes the summary to render.
- **Config knob**: `config.md` gains a Task Journal section with `Session Summary: on` (default). Documented in `.claude/skills/config-format.md`.
- **Tests**: 5 new cases — 2 for `render --summary-file`, 3 end-to-end for session-end (unavailable-claude fallback, stubbed-claude success, knob=off respected). 27/27 across the harness.

## Stack
Base = `slice-3-session-end-hook` (#38). Slice 5 (SessionStart) stacks next.

## Test plan
- [ ] `bats tests/` — 27/27 green
- [ ] In a task folder with `Session Summary: on`, end a Claude session → `[session]` entry contains both a summary block and repo changes
- [ ] Set `Session Summary: off` in `config.md`, end a session → `[session]` entry contains repo changes only, no summary block
- [ ] Break `claude` (unset PATH to it) with knob `on` → hook still writes a valid delta-only entry, no errors