### PR TITLE
Slice 5: SessionStart hook + resume brief

### DIFF
--- a/.claude/hooks/journal-ops.py
+++ b/.claude/hooks/journal-ops.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Module A — journal file operations.
 
-Deterministic parse/rewrite of a task-folder JOURNAL.md. Three subcommands:
+Deterministic parse/rewrite of a task-folder JOURNAL.md. Subcommands:
 
   journal-ops.py read-state <path>
-  journal-ops.py write-state <path>   # reads new state from stdin
-  journal-ops.py append-log <path>    # reads log entry from stdin
+  journal-ops.py write-state <path>         # reads new state from stdin
+  journal-ops.py append-log <path>          # reads log entry from stdin
+  journal-ops.py last-log <path> <count>    # prints the last <count> entries
 
 Contract (see notes/templates/journal.md and PRD #28):
   - The state region is the text from the first `## Current State` heading
@@ -95,6 +96,48 @@ def write_state(path: Path, new_state: str) -> None:
     path.write_text(prefix + new_state + log)
 
 
+def split_log_entries(log_text: str) -> list[str]:
+    """Split the ## Log section body into individual entry strings.
+
+    Each entry starts at a `### ` heading. Text before the first `### `
+    (typically the `<!-- Append-only. ... -->` comment + blank line) is
+    discarded; entries returned include their own heading lines.
+    """
+    lines = log_text.splitlines(keepends=True)
+    entries: list[list[str]] = []
+    current: list[str] | None = None
+    seen_heading = False
+    for line in lines:
+        if line.startswith("### "):
+            if current is not None:
+                entries.append(current)
+            current = [line]
+            seen_heading = True
+            continue
+        # Skip the `## Log` heading itself if we encounter it here.
+        if line.rstrip("\n") == LOG_HEADING:
+            continue
+        if not seen_heading:
+            continue
+        if current is not None:
+            current.append(line)
+    if current is not None:
+        entries.append(current)
+    return ["".join(e).rstrip("\n") + "\n" for e in entries]
+
+
+def read_last_log(path: Path, count: int) -> str:
+    text = path.read_text()
+    _, _, log = split_file(text)
+    if not log:
+        return ""
+    entries = split_log_entries(log)
+    if count <= 0:
+        return ""
+    tail = entries[-count:]
+    return "\n".join(tail)
+
+
 def append_log(path: Path, entry: str) -> None:
     text = path.read_text()
     entry = entry.rstrip("\n") + "\n"
@@ -150,6 +193,21 @@ def main(argv: list[str]) -> int:
             print(f"journal-ops: no such file: {path}", file=sys.stderr)
             return 1
         append_log(path, sys.stdin.read())
+        return 0
+
+    if cmd == "last-log":
+        if len(argv) < 4:
+            print("usage: journal-ops.py last-log <path> <count>", file=sys.stderr)
+            return 2
+        if not path.exists():
+            print(f"journal-ops: no such file: {path}", file=sys.stderr)
+            return 1
+        try:
+            count = int(argv[3])
+        except ValueError:
+            print(f"journal-ops: count must be an integer: {argv[3]}", file=sys.stderr)
+            return 2
+        sys.stdout.write(read_last_log(path, count))
         return 0
 
     print(f"journal-ops: unknown subcommand: {cmd}", file=sys.stderr)

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Claude Code SessionStart hook for eddy task folders.
+#
+# On session start, if the CWD has a JOURNAL.md, emit a resume brief as
+# the hook's additional context: current journal state + last 3 log
+# entries + open todos from the workflow repo's running.md filtered to
+# this task's workstream.
+#
+# The hook writes a JSON object to stdout using Claude Code's
+# `hookSpecificOutput.additionalContext` contract. Exits 0 with no
+# output when there's nothing useful to say.
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_REPO="$(cd "${HOOK_DIR}/../.." && pwd)"
+TASK_FOLDER="$PWD"
+JOURNAL="${TASK_FOLDER}/JOURNAL.md"
+RUNNING="${WORKFLOW_REPO}/notes/todos/running.md"
+
+if [ ! -f "$JOURNAL" ]; then
+  exit 0
+fi
+
+# Drain any stdin payload — Claude Code may send JSON here.
+if [ ! -t 0 ]; then
+  cat > /dev/null
+fi
+
+# Workstream from the journal's frontmatter.
+workstream="$(
+  awk '
+    BEGIN { in_fm = 0 }
+    /^---[[:space:]]*$/ {
+      if (in_fm == 0) { in_fm = 1; next }
+      else { exit }
+    }
+    in_fm == 1 && /^workstream:/ {
+      sub(/^workstream:[[:space:]]*/, "", $0)
+      print $0
+      exit
+    }
+  ' "$JOURNAL"
+)"
+
+STATE="$("${HOOK_DIR}/journal-ops.py" read-state "$JOURNAL")"
+RECENT="$("${HOOK_DIR}/journal-ops.py" last-log "$JOURNAL" 3)"
+
+TODOS=""
+if [ -n "$workstream" ] && [ -f "$RUNNING" ]; then
+  # Match unchecked items whose inline `workstream: <ws>` field equals
+  # the journal's workstream. Case-sensitive substring is sufficient
+  # given eddy's kebab-case workstream convention.
+  TODOS="$(
+    grep -E '^- \[ \]' "$RUNNING" 2>/dev/null \
+      | grep -F "workstream: ${workstream}" \
+      || true
+  )"
+fi
+
+# Compose the brief as markdown.
+brief=""
+brief+="## Resume: $(basename "$TASK_FOLDER")"$'\n'
+if [ -n "$workstream" ]; then
+  brief+="Workstream: **${workstream}**"$'\n'
+fi
+brief+=$'\n'
+
+if [ -n "$STATE" ]; then
+  brief+="### Journal state"$'\n'$'\n'
+  brief+="${STATE}"$'\n'
+fi
+
+if [ -n "$RECENT" ]; then
+  brief+=$'\n'"### Recent journal log (last 3)"$'\n'$'\n'
+  brief+="${RECENT}"$'\n'
+fi
+
+if [ -n "$TODOS" ]; then
+  brief+=$'\n'"### Open todos for this workstream"$'\n'$'\n'
+  brief+="${TODOS}"$'\n'
+fi
+
+# Emit the Claude Code SessionStart hook contract.
+python3 - "$brief" <<'PY'
+import json, sys
+brief = sys.argv[1]
+payload = {
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": brief,
+    }
+}
+json.dump(payload, sys.stdout)
+sys.stdout.write("\n")
+PY

--- a/.claude/skills/checkpoint/SKILL.md
+++ b/.claude/skills/checkpoint/SKILL.md
@@ -134,13 +134,23 @@ On yes:
    `## Work Stream` line and the folder name), otherwise ask the user.
 2. Copy the template to `./JOURNAL.md`, substituting `{{task}}`,
    `{{workstream}}`, and `{{created}}` (today's date).
-3. Install the `SessionEnd` hook into `./.claude/settings.json` so
-   auto-capture works going forward. Write (merging with any existing
-   file):
+3. Install the `SessionStart` and `SessionEnd` hooks into
+   `./.claude/settings.json` so auto-resume and auto-capture work
+   going forward. Write (merging with any existing file):
 
    ```json
    {
      "hooks": {
+       "SessionStart": [
+         {
+           "hooks": [
+             {
+               "type": "command",
+               "command": "<absolute-workflow-repo>/.claude/hooks/session-start.sh"
+             }
+           ]
+         }
+       ],
        "SessionEnd": [
          {
            "hooks": [
@@ -157,14 +167,11 @@ On yes:
 
    `<absolute-workflow-repo>` is the absolute path to the workflow repo
    (parse it from the task folder's `CLAUDE.md` Workflow Repo line if
-   present, else ask the user). If a SessionEnd hook already exists
-   pointing elsewhere, ask before replacing.
+   present, else ask the user). If a hook entry already points
+   elsewhere, ask before replacing.
 4. Proceed with steps 2–3 as normal.
 
 On no: stop silently.
-
-Slice 5 of PRD #28 will add a `SessionStart` hook alongside this
-install step.
 
 ### 6. Append a daily log entry
 

--- a/.claude/skills/new-task/SKILL.md
+++ b/.claude/skills/new-task/SKILL.md
@@ -90,11 +90,21 @@ Then match the task to a work stream:
 
 7. Create `<dev-dir>/<task-name>/JOURNAL.md` from `notes/templates/journal.md`, substituting `{{task}}` with the kebab-case task name, `{{workstream}}` with the matched work stream name, and `{{created}}` with today's date (`YYYY-MM-DD`). The rest of the template (state header, empty `## Log`) is written through unchanged. The journal stays local to the task folder — it is not copied into the vault. If `JOURNAL.md` already exists in the folder, leave it alone rather than overwriting.
 
-8. Install the SessionEnd hook into the task folder's `.claude/settings.json` so each Claude Code session auto-appends a `[session]` log entry to `JOURNAL.md` on exit. Write (merging with any existing file):
+8. Install the `SessionStart` and `SessionEnd` hooks into the task folder's `.claude/settings.json` so each Claude Code session auto-resumes from the journal on entry and auto-captures a `[session]` log entry on exit. Write (merging with any existing file):
 
    ```json
    {
      "hooks": {
+       "SessionStart": [
+         {
+           "hooks": [
+             {
+               "type": "command",
+               "command": "<absolute-workflow-repo>/.claude/hooks/session-start.sh"
+             }
+           ]
+         }
+       ],
        "SessionEnd": [
          {
            "hooks": [
@@ -109,7 +119,7 @@ Then match the task to a work stream:
    }
    ```
 
-   Substitute `<absolute-workflow-repo>` with the same absolute path used in the task `CLAUDE.md`'s Workflow Repo section. If `.claude/settings.json` already exists in the folder, merge the `hooks.SessionEnd` entry in rather than overwriting the file. If it already has a SessionEnd hook pointing elsewhere, ask the user before replacing.
+   Substitute `<absolute-workflow-repo>` with the same absolute path used in the task `CLAUDE.md`'s Workflow Repo section. If `.claude/settings.json` already exists in the folder, merge the `hooks.SessionStart` / `hooks.SessionEnd` entries in rather than overwriting the file. If a hook entry already points elsewhere, ask the user before replacing.
 
 #### 4b. Non-Coding Mode
 
@@ -153,7 +163,7 @@ Create the `## Tasks` section just above `## Notes` if it's missing. No `ended:`
 
 Tell the user:
 
-- **Coding mode:** task folder location, what was cloned, the `CLAUDE.md` + `AGENTS.md` symlink, the scaffolded `JOURNAL.md`, the `.claude/settings.json` with the `SessionEnd` hook wired up, the work stream `## Tasks` bullet appended (quote the line), the daily log entry, and how to resume (`cd <folder>` and launch Claude Code or Codex).
+- **Coding mode:** task folder location, what was cloned, the `CLAUDE.md` + `AGENTS.md` symlink, the scaffolded `JOURNAL.md`, the `.claude/settings.json` with the `SessionStart` and `SessionEnd` hooks wired up, the work stream `## Tasks` bullet appended (quote the line), the daily log entry, and how to resume (`cd <folder>` and launch Claude Code or Codex).
 - **Non-coding mode:** the captured task name, work stream, and output type; the work stream `## Tasks` bullet (quote the line); the daily log entry; and a reminder that the output file wasn't pre-created — the user is expected to produce it themselves.
 
 ## Important Rules

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,9 +29,10 @@ Add `--print-output-on-failure` to see stdout/stderr from failing cases.
 
 | Path                          | What it covers                                         |
 |-------------------------------|--------------------------------------------------------|
-| `tests/journal-ops.bats`      | Module A — state rewrite + log append                  |
+| `tests/journal-ops.bats`      | Module A — state rewrite + log append + last-log       |
 | `tests/git-delta.bats`        | Module B — git delta collect + render                  |
 | `tests/session-end.bats`      | Integration — SessionEnd hook end-to-end               |
+| `tests/session-start.bats`    | Integration — SessionStart hook end-to-end             |
 | `tests/fixtures/`             | Sample `JOURNAL.md` files used by the tests            |
 
 ## Writing tests

--- a/tests/journal-ops.bats
+++ b/tests/journal-ops.bats
@@ -147,3 +147,25 @@ not_contains() {
   contains "${WORK}/j.md" "## Log"
   contains "${WORK}/j.md" "Entry."
 }
+
+@test "last-log returns the last N entries including their body" {
+  run "$OPS" last-log "${FIXTURES}/journal-populated.md" 1
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "narrowed to token-refresh"
+  echo "$output" | grep -qF "Confirmed the race is in refresh"
+  # Earlier entry must NOT be in the output.
+  ! echo "$output" | grep -qF "initial exploration"
+}
+
+@test "last-log with N greater than entry count returns all entries" {
+  run "$OPS" last-log "${FIXTURES}/journal-populated.md" 10
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "initial exploration"
+  echo "$output" | grep -qF "narrowed to token-refresh"
+}
+
+@test "last-log on journal with no entries returns empty output" {
+  run "$OPS" last-log "${FIXTURES}/journal-empty-log.md" 3
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/tests/session-start.bats
+++ b/tests/session-start.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+# Integration tests for .claude/hooks/session-start.sh.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  HOOK="${REPO_ROOT}/.claude/hooks/session-start.sh"
+  TEMPLATE="${REPO_ROOT}/notes/templates/journal.md"
+  TASK="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TASK"
+}
+
+make_journal() {
+  # make_journal <workstream>
+  cp "$TEMPLATE" "${TASK}/JOURNAL.md"
+  # Substitute workstream placeholder.
+  python3 - "${TASK}/JOURNAL.md" "$1" <<'PY'
+import sys
+path, ws = sys.argv[1], sys.argv[2]
+text = open(path).read().replace("{{workstream}}", ws)
+open(path, "w").write(text)
+PY
+}
+
+@test "session-start no-ops when JOURNAL.md is absent" {
+  bare="$(mktemp -d)"
+  run bash -c "(cd '$bare' && '$HOOK' < /dev/null)"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  rmdir "$bare"
+}
+
+@test "session-start emits a JSON payload with journal state when present" {
+  make_journal "platform-auth"
+
+  # Write in a real state section so read-state returns content.
+  new_state=$(cat <<'EOF'
+## Current State
+Hacking on the refresh token path.
+
+## Next Steps
+- Repro the race
+
+## Open Questions
+
+## Blockers
+EOF
+)
+  printf '%s\n' "$new_state" | "${REPO_ROOT}/.claude/hooks/journal-ops.py" write-state "${TASK}/JOURNAL.md"
+
+  # Append a log entry so recent-log output is non-empty.
+  printf '### [checkpoint] 2026-04-22T10:00:00Z — set up repro harness\n\nBuilt a script.\n' \
+    | "${REPO_ROOT}/.claude/hooks/journal-ops.py" append-log "${TASK}/JOURNAL.md"
+
+  run bash -c "(cd '$TASK' && '$HOOK' < /dev/null)"
+  [ "$status" -eq 0 ]
+  # Output must be parseable JSON with additionalContext.
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['hookSpecificOutput']['hookEventName'] == 'SessionStart', d
+ctx = d['hookSpecificOutput']['additionalContext']
+assert 'Hacking on the refresh token path.' in ctx, ctx
+assert 'set up repro harness' in ctx, ctx
+assert 'platform-auth' in ctx, ctx
+"
+}
+
+@test "session-start filters running.md by the journal's workstream" {
+  make_journal "platform-auth"
+
+  # Stage a fake workflow repo layout for RUNNING=.../notes/todos/running.md.
+  # Hook resolves WORKFLOW_REPO from its own path, so running.md must live
+  # in this repo's actual notes/ for the hook to find it. We add entries
+  # then remove them in teardown.
+  running="${REPO_ROOT}/notes/todos/running.md"
+  mkdir -p "$(dirname "$running")"
+  cat > "$running" <<'RM'
+- [ ] Match me — workstream: platform-auth | added: 2026-04-20
+- [ ] Not me — workstream: other-stream | added: 2026-04-20
+- [x] Completed irrelevant — workstream: platform-auth | added: 2026-04-15
+RM
+
+  run bash -c "(cd '$TASK' && '$HOOK' < /dev/null)"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+ctx = d['hookSpecificOutput']['additionalContext']
+assert 'Match me' in ctx, ctx
+assert 'Not me' not in ctx, ctx
+assert 'Completed irrelevant' not in ctx, ctx
+"
+
+  rm -f "$running"
+}
+
+@test "session-start tolerates JSON payload on stdin" {
+  make_journal "demo"
+  payload='{"session_id":"abc","source":"startup"}'
+  run bash -c "(cd '$TASK' && printf '%s' '$payload' | '$HOOK')"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['hookSpecificOutput']['hookEventName'] == 'SessionStart'
+"
+}


### PR DESCRIPTION
Closes #33 (part of PRD #28). Stacked on top of #39 (slice 4).

## Summary
- **Module A** gets a `last-log <path> <count>` subcommand — returns the tail N `## Log` entries (heading + body).
- **SessionStart hook** (`.claude/hooks/session-start.sh`): parses the journal's workstream from frontmatter, reads state + last 3 log entries via Module A, filters `notes/todos/running.md` to unchecked items whose inline `workstream:` matches the journal's. Emits the combined brief as `hookSpecificOutput.additionalContext` JSON per Claude Code's contract. No-ops cleanly on journal-less folders.
- **`/new-task` + `/checkpoint` init path** now install the SessionStart entry alongside slice-3's SessionEnd entry in `.claude/settings.json`.
- **Tests**: 3 new `last-log` cases + 4 `session-start` integration cases. 34/34 across the harness.

## Stack
Base = `slice-4-llm-summary` (#39). Slice 6 (completion retrospective) stacks next.

## Test plan
- [ ] `bats tests/` — 34/34 green
- [ ] `cd` into an existing journal-enabled task folder, launch `claude` → first turn acknowledges the journal's current state + last 3 log entries + workstream-filtered todos
- [ ] `cd` into a folder without `JOURNAL.md`, launch `claude` → no hook output, no errors
- [ ] `/new-task` on a fresh task → `.claude/settings.json` contains both `SessionStart` and `SessionEnd` entries