### PR TITLE
Slice 6: completion workflow retrospective

### DIFF
--- a/notes/templates/task.md
+++ b/notes/templates/task.md
@@ -37,9 +37,52 @@ When the user reports a task done — by saying "I completed <task>", "I finishe
 
 1. Parse a completion date from the user's phrase (today if unstated; resolve "yesterday", "last Tuesday", "on April 14", etc. against today). If ambiguous, ask.
 2. Find the matching open bullet in a work stream's `## Tasks` section (search by task-name first, then substring on the description). Ask to disambiguate if multiple open tasks match. If the only match is already completed, ask whether to overwrite.
-3. Append ` | ended: YYYY-MM-DD` to that line in place. Don't touch any other section of the work stream file, and don't modify the `started:` date.
-4. Append an entry to today's daily log: `- **HH:MM** — [complete-task] Marked "<task-name>" ended <YYYY-MM-DD> in [[<work-stream>]]`.
-5. Tell the user what line was updated and the task's duration (end − start).
+3. **If the task has a `JOURNAL.md` (coding task with a scaffolded task folder), synthesize a retrospective and gate the workstream write on user approval** — see "Retrospective synthesis" below.
+4. Append ` | ended: YYYY-MM-DD` to the matched bullet in place. Don't touch any other section of the work stream file, and don't modify the `started:` date.
+5. Append an entry to today's daily log: `- **HH:MM** — [complete-task] Marked "<task-name>" ended <YYYY-MM-DD> in [[<work-stream>]]`.
+6. Tell the user what line was updated, the task's duration (end − start), and — if a retrospective was written — that the work stream's `## Notes` section was updated.
+
+**Task folder is left intact** (cloned repos, unpushed branches, `JOURNAL.md` history). The user deletes it manually once they're sure nothing is left behind.
+
+## Retrospective synthesis
+
+This step runs only when the task has a populated `JOURNAL.md`. When the matched bullet is a non-coding task or the task folder has no `JOURNAL.md` (pre-feature folder, manually removed, non-coding task, etc.), **skip this section entirely** and fall through to step 4 unchanged.
+
+Locate the task folder: read `config.md` for the Dev Directory (default `~/dev`), then look for `<dev-dir>/<task-name>/JOURNAL.md`. If the folder or journal is absent, skip.
+
+If present:
+
+1. Read the journal:
+   - State header via `.claude/hooks/journal-ops.py read-state <path>`.
+   - Full `## Log` section (all `[session]` and `[checkpoint]` entries).
+2. Synthesize a retrospective block with exactly these four subsections, in this order:
+
+   ```markdown
+   ### Retrospective: <task-name> (ended YYYY-MM-DD)
+
+   **Outcome**
+   <2–4 sentences on what shipped, what didn't, and why.>
+
+   **Key Decisions**
+   - <decision 1, with short rationale>
+   - <decision 2>
+
+   **Outputs / PRs**
+   - <PR link, doc, artifact — use [[wikilinks]] for PR notes like [[repo-123]] if present>
+
+   **Lessons / Follow-ups**
+   - <one insight or open thread worth remembering>
+   ```
+
+   Draw only from the journal + well-known project context (repos.md, ARCHITECTURE.md). Do not invent outcomes that aren't attested by the journal.
+3. Show the draft to the user and ask for explicit approval:
+   > "I'll append this retrospective to `notes/workstreams/<work-stream>.md` under `## Notes`. OK to write as-is, edit first, or skip?"
+4. **Only on approval**, append the retrospective block to the workstream's `## Notes` section. Preserve all other sections exactly.
+   - If the user asks to edit: iterate on the draft, then re-confirm before writing.
+   - If the user declines: skip the workstream write entirely and proceed to step 4 of the outer flow. Completion still succeeds.
+5. Do NOT modify `notes/todos/running.md` from this flow — the journal's Next Steps section is private to the task and does not sync to the running list.
+
+This matches eddy's standing rule: never modify a work stream file without explicit user confirmation (see `vault-conventions.md`).
 
 ## Rules
 


### PR DESCRIPTION
Closes #34 (part of PRD #28). Stacked on top of #40 (slice 5).

## Summary
Extends `notes/templates/task.md` completion workflow. When the user says "I finished X" and the matched task folder has a populated `JOURNAL.md`:

1. Read state + full `## Log` via Module A.
2. Synthesize a retrospective (Outcome / Key Decisions / Outputs-PRs / Lessons-Follow-ups).
3. Show the draft; on approval, append to the workstream's `## Notes` section.
4. Fall through to the existing `| ended:` bullet + daily-log append (unchanged).

Non-coding tasks, pre-feature folders, and folders with a removed `JOURNAL.md` fall through to today's behavior. Task folders and their contents are left intact on completion.

Prompt-only change — no new code, no new tests.

## Stack
Base = `slice-5-session-start-hook` (#40). Slice 7 (Codex smoke + polish) stacks next.

## Test plan
- [ ] Complete a task with populated `JOURNAL.md` → retrospective draft shown; approval writes to workstream `## Notes`; `| ended:` bullet + daily-log entry both land
- [ ] User rejects retrospective draft → workstream `## Notes` untouched; `| ended:` bullet + daily-log still land
- [ ] Complete a task whose folder has no `JOURNAL.md` → no synthesis, no prompt, behavior identical to pre-PRD
- [ ] Complete a non-coding task → no folder lookup, no synthesis, identical to pre-PRD
- [ ] Confirm `notes/todos/running.md` is not touched in any path