### PR TITLE
Slice 7: Codex smoke + docs polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,19 @@ See also:
 - `.claude/skills/workstream-format.md` — Work stream conventions
 - `.claude/skills/ticket-format.md` — Unified ticket schema (Jira, Linear)
 - `.claude/skills/config-format.md` — How to parse config.md
+
+## Task Journal
+
+Each coding task folder scaffolded by `/new-task` contains a `JOURNAL.md`. Claude Code `SessionStart` and `SessionEnd` hooks (installed by `/new-task` into the task folder's `.claude/settings.json`) auto-resume and auto-capture work across sessions. `/checkpoint` lets the agent (or user) mark state explicitly mid-session.
+
+The hook scripts and the deep helpers live under `.claude/hooks/`:
+
+| File | Role |
+|------|------|
+| `journal-ops.py` | Module A — read/write state region, append/read log entries |
+| `git-delta.py` | Module B — collect commits/files across child repos, render markdown |
+| `session-start.sh` | Emits resume brief (state + last 3 log entries + filtered todos) |
+| `session-end.sh` | Appends `[session]` entry with git delta + optional LLM summary |
+| `summarize-transcript.sh` | Module C — wraps `claude -p` for the session summary |
+
+Bats tests for Modules A and B + hook integration live in `tests/`. Install with `brew install bats-core` and run `bats tests/`.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ Powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Cod
 - YAML frontmatter on every note
 - `[[wikilinks]]` between notes, `#tags` in body
 - Every skill appends to the daily log
-- Work streams are **never** auto-created — always confirm
+- Work streams are **never** auto-created or auto-modified — always confirm
+
+### Auto-capture (Claude Code only)
+Each coding task folder gets a `JOURNAL.md` plus `SessionStart` / `SessionEnd` hooks installed by `/new-task`. The `SessionEnd` hook appends a `[session]` entry with a git delta (and, by default, a 2–3 sentence LLM summary) to the journal. The `SessionStart` hook replays the journal state + filtered todos into the agent's first turn so you pick up where you left off. `/checkpoint` lets you mark state between sessions. See [`docs/migrations/task-journal.md`](docs/migrations/task-journal.md) to adopt it in existing task folders.
 
 ### Key Files
 - `config.md` — GitHub user, prefs, integrations
@@ -74,4 +77,4 @@ Powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Cod
 - `ARCHITECTURE.md` — System overview
 
 ### Upgrading an existing vault
-See [docs/migrations/](docs/migrations/) for guides covering schema changes. Most recent: [running-todos](docs/migrations/running-todos.md) — single running todo list + work streams as doc-of-docs.
+See [docs/migrations/](docs/migrations/) for guides covering schema changes. Most recent: [task-journal](docs/migrations/task-journal.md) — per-task `JOURNAL.md` + `SessionStart`/`SessionEnd` hooks + `/checkpoint`.

--- a/docs/migrations/task-journal.md
+++ b/docs/migrations/task-journal.md
@@ -1,0 +1,37 @@
+# Task Journal Migration Guide
+
+Eddy now adds a per-task `JOURNAL.md` to every coding task folder, plus Claude Code `SessionStart` / `SessionEnd` hooks that auto-resume and auto-capture work across sessions. `/checkpoint` lets you mark state explicitly, and the task-completion workflow can synthesize a retrospective into the work stream.
+
+New task folders created via `/new-task` get all of this automatically. This guide covers adopting it in task folders that existed before the change.
+
+## What changed
+
+- **`notes/templates/journal.md`** — new per-task journal template (frontmatter + state header + append-only `## Log`).
+- **`.claude/hooks/`** — new directory with `journal-ops.py` (state/log ops), `git-delta.py` (delta collector + entry renderer), `session-start.sh` (resume brief), `session-end.sh` (auto-capture), and `summarize-transcript.sh` (optional LLM session summary).
+- **`/checkpoint`** — new skill that rewrites `JOURNAL.md` state and appends `[checkpoint]` log entries. `--promote` additionally drafts a dated line into the work stream's `## Notes` section (user approval required).
+- **`/new-task`** — coding mode now scaffolds `JOURNAL.md` and installs both hooks in the task folder's `.claude/settings.json`.
+- **Task completion** — coding tasks with a populated `JOURNAL.md` can synthesize a retrospective into the work stream's `## Notes` (approval gated). Non-coding tasks and journal-less folders fall through unchanged.
+- **`config.md`** — new Task Journal section with a `Session Summary: on | off` knob (default `on`).
+
+`running.md` is never touched by the journal; work streams are never modified without explicit user approval (matching eddy's existing rule).
+
+## Adopting in existing task folders
+
+Inside each pre-existing task folder, run `/checkpoint`. If no `JOURNAL.md` is found, the skill will offer to initialize one and install the hooks — one shot, no manual editing needed. Say yes and you're done.
+
+If you skip that step, each folder continues to work exactly as before: the hooks only run where they're installed, and all other skills behave as they did pre-migration.
+
+## Disabling the LLM summary
+
+The only variable-cost piece is the 2–3 sentence transcript summary in each `SessionEnd` entry. Flip it off by editing `config.md`:
+
+```markdown
+## Task Journal
+- **Session Summary:** off
+```
+
+With the knob off, `SessionEnd` still writes the git-delta portion of each `[session]` entry — no summary, no `claude -p` invocation.
+
+## Codex
+
+Codex sessions continue to work through the existing `AGENTS.md → CLAUDE.md` symlink. They do not run Claude Code hooks, so they do not write to `JOURNAL.md`. Parity with the pre-journal flow is preserved.


### PR DESCRIPTION
Closes #35 (part of PRD #28). Stacked on top of #41 (slice 6). Final slice of the PRD stack.

## Summary
- `docs/migrations/task-journal.md`: adoption guide for existing task folders. `/checkpoint` handles retroactive install; `Session Summary: off` disables the only variable-cost piece.
- README gains an "Auto-capture (Claude Code only)" blurb and points the Upgrading section at the new migration doc.
- Top-level `CLAUDE.md` gains a "Task Journal" section with a file-by-file map of `.claude/hooks/` and the `bats tests/` workflow.
- Codex smoke: Codex runs via `AGENTS.md → CLAUDE.md` symlink with no Claude Code hooks — parity is inherent, nothing code-side to change.
- 34/34 tests still green.

## Stack
Tip of the stack. Base = `slice-6-completion-retrospective` (#41).

## Test plan
- [ ] `bats tests/` — 34/34 green
- [ ] Skim README + CLAUDE.md — `/checkpoint`, JOURNAL.md, hook directory, config knob, and tests are all discoverable from the top
- [ ] Run `/new-task` end-to-end once more → confirm `## Tasks` bullet + daily-log behavior unchanged vs pre-PRD (PRD user story 24 regression guard)
- [ ] Open a journal-enabled folder with Codex → works as today, no errors, no journal writes (PRD user story 18)